### PR TITLE
 [KHS] SQL injection hardening — alias validation and sortBy allowlists                                                                 

### DIFF
--- a/src/admin/services/admin.service.ts
+++ b/src/admin/services/admin.service.ts
@@ -1,6 +1,7 @@
 import {BadRequestException, Injectable, UnauthorizedException} from '@nestjs/common';
 import {InjectRepository} from '@nestjs/typeorm';
 import {Repository} from 'typeorm';
+import { SqlSafeHelper } from '../../helpers/sql-safe.helper';
 import {EmailService} from "../../email/email.service";
 import {User} from "../../all_user_entities/user.entity";
 import {Business, BusinessStatus} from "../../business/entities/business.entity";
@@ -39,19 +40,14 @@ export class AdminService {
 
         const radius = 15;
 
-        const businesses = await this.businessRepo
-            .createQueryBuilder('business')
-            .addSelect(`
-        (6371 * acos(
-          cos(radians(:userLat)) *
-          cos(radians(business.latitude)) *
-          cos(radians(business.longitude) - radians(:userLng)) +
-          sin(radians(:userLat)) *
-          sin(radians(business.latitude))
-        ))`, 'distance'
+        const businesses = await SqlSafeHelper
+            .haversineWhere(
+              this.businessRepo.createQueryBuilder('business'),
+              'business',
+              userLat,
+              userLng,
+              radius,
             )
-            .having('distance <= :radius', { radius })
-            .setParameters({ userLat, userLng })
             .orderBy('distance', 'ASC')
             .getRawMany();
 

--- a/src/business/services/business-giftcard.service.ts
+++ b/src/business/services/business-giftcard.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Not, Repository } from 'typeorm';
+import { SqlSafeHelper } from 'src/helpers/sql-safe.helper';
 import { BusinessGiftCard } from '../entities/business-giftcard.entity';
 import {
   BusinessGiftCardFiltersDto,
@@ -19,6 +20,19 @@ import {
   BusinessSentStatus,
 } from '../enum/gift-card.enum';
 import { Business } from '../entities/business.entity';
+
+const GIFT_CARD_SORT_COLUMNS = [
+  'createdAt',
+  'updatedAt',
+  'amount',
+  'remainingAmount',
+  'expiresAt',
+  'redeemedAt',
+  'title',
+  'status',
+  'sentStatus',
+  'soldStatus',
+] as const;
 
 @Injectable()
 export class BusinessGiftCardsService {
@@ -193,8 +207,9 @@ export class BusinessGiftCardsService {
     /* --------- SORTING (APPLIED ONCE!) ---------- */
 
     // Otherwise follow user-defined sortBy and sortOrder
+    const safeSort = SqlSafeHelper.validateSortColumn(sortBy, GIFT_CARD_SORT_COLUMNS, 'createdAt');
     queryBuilder.orderBy(
-      `giftCard.${sortBy}`,
+      `giftCard.${safeSort}`,
       sortOrder.toUpperCase() as 'ASC' | 'DESC',
     );
 

--- a/src/business/services/client.service.ts
+++ b/src/business/services/client.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
+import { SqlSafeHelper } from 'src/helpers/sql-safe.helper';
 import {
   ClientFormData,
   ClientlistResponse,
@@ -27,6 +28,20 @@ import {
 import { PasswordHashingHelper } from 'src/helpers/password-hashing.helper';
 import { User } from 'src/all_user_entities/user.entity';
 import sgMail from '@sendgrid/mail';
+
+const CLIENT_SORT_COLUMNS = [
+  'firstName',
+  'lastName',
+  'email',
+  'phone',
+  'clientType',
+  'dateOfBirth',
+  'gender',
+  'clientSource',
+  'isActive',
+  'createdAt',
+  'updatedAt',
+] as const;
 
 @Injectable()
 export class ClientService {
@@ -506,10 +521,9 @@ export class ClientService {
       }
 
       // Sorting
-      const sortColumn =
-        sortBy === 'createdAt' ? 'client.createdAt' : `client.${sortBy}`;
+      const safeSort = SqlSafeHelper.validateSortColumn(sortBy, CLIENT_SORT_COLUMNS, 'createdAt');
       queryBuilder.orderBy(
-        sortColumn,
+        `client.${safeSort}`,
         sortOrder.toUpperCase() as 'ASC' | 'DESC',
       );
 

--- a/src/business/services/wallet.service.ts
+++ b/src/business/services/wallet.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { SqlSafeHelper } from 'src/helpers/sql-safe.helper';
 import { Wallet } from '../entities/wallet.entity';
 import {
   AddPaymentMethodDto,
@@ -29,6 +30,16 @@ import {
 import { WalletPaymentMethod } from '../entities/payment-method.entity';
 import { Withdrawal } from 'src/admin/withdrawal/entities/withdrawal.entity';
 import { Business } from '../entities/business.entity';
+
+const TRANSACTION_SORT_COLUMNS = [
+  'amount',
+  'type',
+  'description',
+  'status',
+  'method',
+  'createdAt',
+  'updatedAt',
+] as const;
 
 @Injectable()
 export class BusinessWalletService {
@@ -607,8 +618,9 @@ export class BusinessWalletService {
       /* --------- SORTING (APPLIED ONCE!) ---------- */
 
       // Otherwise follow user-defined sortBy and sortOrder
+      const safeSort = SqlSafeHelper.validateSortColumn(sortBy, TRANSACTION_SORT_COLUMNS, 'createdAt');
       queryBuilder.orderBy(
-        `transaction.${sortBy}`,
+        `transaction.${safeSort}`,
         sortOrder.toUpperCase() as 'ASC' | 'DESC',
       );
 

--- a/src/helpers/sql-safe.helper.ts
+++ b/src/helpers/sql-safe.helper.ts
@@ -1,0 +1,102 @@
+import { ObjectLiteral, SelectQueryBuilder } from 'typeorm';
+
+const SAFE_ALIAS_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+const SQL_RESERVED_WORDS = new Set([
+  'select', 'from', 'where', 'table', 'order', 'group',
+  'by', 'join', 'inner', 'outer', 'left', 'right', 'on',
+  'insert', 'update', 'delete', 'drop', 'create', 'alter',
+  'index', 'into', 'values', 'set', 'having', 'limit',
+  'offset', 'union', 'all', 'distinct', 'as', 'case',
+  'when', 'then', 'else', 'end', 'null', 'true', 'false',
+]);
+
+export class SqlSafeHelper {
+  /**
+   * Enforces that alias is a valid SQL identifier at runtime.
+   * Throws before the alias is ever written into a query string.
+   */
+  private static validateAlias(alias: string): void {
+    if (!SAFE_ALIAS_PATTERN.test(alias)) {
+      throw new Error(
+        'SQL alias failed validation: must start with a letter or underscore ' +
+        'and contain only letters, digits, and underscores.',
+      );
+    }
+
+    if (SQL_RESERVED_WORDS.has(alias.toLowerCase())) {
+      throw new Error(
+        'SQL alias failed validation: value is a reserved SQL keyword ' +
+        'and cannot be used as a query alias.',
+      );
+    }
+  }
+
+  /**
+   * Adds a Haversine distance SELECT to the query using named parameters.
+   * Use this when you need the distance column for ordering only.
+   */
+  static haversineSelect<T extends ObjectLiteral>(
+    qb: SelectQueryBuilder<T>,
+    alias: string,
+    lat: number,
+    lng: number,
+  ): SelectQueryBuilder<T> {
+    SqlSafeHelper.validateAlias(alias);
+
+    return qb
+      .addSelect(
+        `ROUND((6371 * ACOS(
+          COS(RADIANS(:__lat)) * COS(RADIANS(${alias}.latitude)) *
+          COS(RADIANS(${alias}.longitude) - RADIANS(:__lng)) +
+          SIN(RADIANS(:__lat)) * SIN(RADIANS(${alias}.latitude))
+        ))::numeric, 2)`,
+        'distance',
+      )
+      .setParameter('__lat', lat)
+      .setParameter('__lng', lng);
+  }
+
+  /**
+   * Adds a Haversine distance SELECT + a WHERE clause that filters rows
+   * within radiusKm. Fixes the HAVING-without-GROUP-BY pattern which only
+   * works as a set-level filter, not a row-level filter.
+   */
+  static haversineWhere<T extends ObjectLiteral>(
+    qb: SelectQueryBuilder<T>,
+    alias: string,
+    lat: number,
+    lng: number,
+    radiusKm: number,
+  ): SelectQueryBuilder<T> {
+    SqlSafeHelper.validateAlias(alias);
+
+    const expr = `6371 * ACOS(
+      COS(RADIANS(:__lat)) * COS(RADIANS(${alias}.latitude)) *
+      COS(RADIANS(${alias}.longitude) - RADIANS(:__lng)) +
+      SIN(RADIANS(:__lat)) * SIN(RADIANS(${alias}.latitude))
+    )`;
+
+    return qb
+      .addSelect(`ROUND((${expr})::numeric, 2)`, 'distance')
+      .andWhere(`(${expr}) <= :__radius`)
+      .setParameter('__lat', lat)
+      .setParameter('__lng', lng)
+      .setParameter('__radius', radiusKm);
+  }
+
+  /**
+   * Validates that sortBy is in the explicit allowlist before using it as a
+   * column name. Falls back to defaultColumn if absent or not in the list.
+   */
+  static validateSortColumn(
+    sortBy: string | undefined,
+    allowedColumns: readonly string[],
+    defaultColumn: string,
+  ): string {
+    if (!sortBy || !allowedColumns.includes(sortBy)) {
+      return defaultColumn;
+    }
+    return sortBy;
+  }
+}

--- a/src/marketplace/services/product.service.ts
+++ b/src/marketplace/services/product.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { SqlSafeHelper } from 'src/helpers/sql-safe.helper';
 import { Product } from '../entity/product.entity';
 import { CreateProductDto, ProductFiltersDto } from '../dto/marketplace.dto';
 import { SkuGeneratorService } from './sku-generator.service';
@@ -15,6 +16,19 @@ import {
   FileUpload,
 } from 'src/business/services/business-cloudinary.service';
 import { Business } from 'src/business/entities/business.entity';
+
+const PRODUCT_SORT_COLUMNS = [
+  'productName',
+  'sellingPrice',
+  'costPrice',
+  'stockQuantity',
+  'category',
+  'shippingStatus',
+  'shippingProgress',
+  'isActive',
+  'createdAt',
+  'updatedAt',
+] as const;
 
 @Injectable()
 export class ProductService {
@@ -189,8 +203,9 @@ export class ProductService {
       queryBuilder.orderBy('product.sellingPrice', 'DESC');
     } else {
       // Otherwise follow user-defined sortBy and sortOrder
+      const safeSort = SqlSafeHelper.validateSortColumn(sortBy, PRODUCT_SORT_COLUMNS, 'createdAt');
       queryBuilder.orderBy(
-        `product.${sortBy}`,
+        `product.${safeSort}`,
         sortOrder.toUpperCase() as 'ASC' | 'DESC',
       );
     }

--- a/src/user/services/salon.service.ts
+++ b/src/user/services/salon.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { SqlSafeHelper } from 'src/helpers/sql-safe.helper';
 
 import { Service } from 'src/business/entities/service.entity';
 import { Business, BusinessStatus } from 'src/business/entities/business.entity';
@@ -87,11 +88,7 @@ export class SalonService {
 
     case 'distance':
       if (lat && lng) {
-        query = query
-          .addSelect(
-            `ROUND((6371 * ACOS(COS(RADIANS(${lat})) * COS(RADIANS(business.latitude)) * COS(RADIANS(business.longitude) - RADIANS(${lng})) + SIN(RADIANS(${lat})) * SIN(RADIANS(business.latitude))))::numeric, 2)`,
-            'distance',
-          )
+        query = SqlSafeHelper.haversineSelect(query, 'business', lat, lng)
           .orderBy('distance', 'ASC');
       }
       break;


### PR DESCRIPTION
What changed and why
  Fixed SQL injection vulnerabilities across 6 service files where user-supplied
  values were interpolated directly into raw SQL query strings.

  Changes
  - New `SqlSafeHelper` class with runtime alias validation (regex + reserved word check)
  - `haversineSelect` and `haversineWhere` using named params instead of raw interpolation
  - `validateSortColumn` with explicit allowlists for all affected services
  - Fixed broken HAVING-without-GROUP-BY in `admin.service.ts getNearbySalons`

  Files affected
  - src/helpers/sql-safe.helper.ts (new helper file created)
  - src/admin/services/admin.service.ts
  - src/business/services/business-giftcard.service.ts
  - src/business/services/client.service.ts
  - src/business/services/wallet.service.ts
  - src/marketplace/services/product.service.ts
  - src/user/services/salon.service.ts

  
