### PR TITLE
DEV-051 - KAYODE - 05 JUL 2026

### DIFF
--- a/src/business/controllers/business-giftcard.controller.ts
+++ b/src/business/controllers/business-giftcard.controller.ts
@@ -32,13 +32,14 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Business } from '../entities/business.entity';
 import { Repository } from 'typeorm';
 import { JwtAuthGuard } from 'src/middleware/jwt-auth.guard';
+import { RolesGuard } from 'src/middleware/roles.guard';
 import { Roles } from 'src/middleware/roles.decorator';
 import { Role } from 'src/middleware/role.enum';
 
 @ApiTags('Business Gift Cards')
 @ApiBearerAuth('access-token')
-// @UseGuards(JwtAuthGuard, RolesGuard)
-// @Roles(Role.Merchant, Role.Staff)
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Merchant, Role.Staff)
 @Controller('business-gift-cards')
 export class BusinessGiftCardsController {
   constructor(

--- a/src/business/controllers/business-owner-settings.controller.ts
+++ b/src/business/controllers/business-owner-settings.controller.ts
@@ -33,8 +33,8 @@ import { Roles } from 'src/middleware/roles.decorator';
 
 @ApiTags('Business Owner Settings')
 @ApiBearerAuth('access-token')
-// @UseGuards(JwtAuthGuard, RolesGuard)
-// @Roles(Role.Merchant, Role.Staff)
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Merchant, Role.Staff)
 @Controller('business-owner-settings')
 export class BusinessOwnerSettingsController {
   constructor(

--- a/src/business/controllers/business-settings.controller.ts
+++ b/src/business/controllers/business-settings.controller.ts
@@ -30,13 +30,14 @@ import {
   UpdateBusinessProfileDto,
 } from '../dtos/requests/BusinessSettingsDto';
 import { JwtAuthGuard } from '../../middleware/jwt-auth.guard';
+import { RolesGuard } from 'src/middleware/roles.guard';
 import { Role } from 'src/middleware/role.enum';
 import { Roles } from 'src/middleware/roles.decorator';
 
 @ApiTags('Business Settings')
 @ApiBearerAuth('access-token')
-// @UseGuards(JwtAuthGuard, RolesGuard)
-// @Roles(Role.Merchant, Role.Staff)
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Merchant, Role.Staff)
 @Controller('business-settings')
 export class BusinessSettingsController {
   constructor(

--- a/src/business/controllers/client.controller.ts
+++ b/src/business/controllers/client.controller.ts
@@ -37,13 +37,14 @@ import {
 import { ClientSettingsService } from '../services/client-settings.service';
 import { Roles } from 'src/middleware/roles.decorator';
 import { JwtAuthGuard } from '../../middleware/jwt-auth.guard';
+import { RolesGuard } from 'src/middleware/roles.guard';
 import { Role } from 'src/middleware/role.enum';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('Business Clients')
 @ApiBearerAuth('access-token')
-// @UseGuards(JwtAuthGuard, RolesGuard)
-// @Roles(Role.Merchant, Role.Staff)
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Merchant, Role.Staff)
 @Controller('clients')
 @UsePipes(new ValidationPipe({ transform: true }))
 export class ClientController {

--- a/src/business/controllers/communication.controller.ts
+++ b/src/business/controllers/communication.controller.ts
@@ -14,15 +14,15 @@ import {
 } from '../dtos/requests/CommunicationDto';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/middleware/jwt-auth.guard';
+import { RolesGuard } from 'src/middleware/roles.guard';
 import { Role } from 'src/middleware/role.enum';
 import { Roles } from 'src/middleware/roles.decorator';
 
 @ApiTags('Business Communication')
 @ApiBearerAuth('access-token')
-// @UseGuards(JwtAuthGuard, RolesGuard)
-// @Roles(Role.Merchant, Role.Staff)
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Merchant, Role.Staff)
 @Controller('communications')
-// @UseGuards(JwtAuthGuard)
 export class CommunicationController {
   constructor(private readonly communicationService: CommunicationService) {}
 

--- a/src/business/controllers/custom-message.controller.ts
+++ b/src/business/controllers/custom-message.controller.ts
@@ -11,13 +11,14 @@ import { CustomMessageService } from '../services/custom-message.service';
 import { SendCustomMessageDto } from '../dtos/requests/CustomMesssageDto';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/middleware/jwt-auth.guard';
+import { RolesGuard } from 'src/middleware/roles.guard';
 import { Role } from 'src/middleware/role.enum';
 import { Roles } from 'src/middleware/roles.decorator';
 
 @ApiTags('Business Custom Message')
 @ApiBearerAuth('access-token')
-// @UseGuards(JwtAuthGuard, RolesGuard)
-// @Roles(Role.Merchant, Role.Staff)
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Merchant, Role.Staff)
 @Controller('custom-messages')
 export class CustomMessageController {
   constructor(private readonly customMessageService: CustomMessageService) {}

--- a/src/business/controllers/promotion.controller.ts
+++ b/src/business/controllers/promotion.controller.ts
@@ -11,13 +11,14 @@ import { PromotionService } from '../services/promotion.service';
 import { SendPromotionDto } from '../dtos/requests/PromotionDto';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/middleware/jwt-auth.guard';
+import { RolesGuard } from 'src/middleware/roles.guard';
 import { Role } from 'src/middleware/role.enum';
 import { Roles } from 'src/middleware/roles.decorator';
 
 @ApiTags('Business Promotion')
 @ApiBearerAuth('access-token')
-// @UseGuards(JwtAuthGuard, RolesGuard)
-// @Roles(Role.Merchant, Role.Staff)
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Merchant, Role.Staff)
 @Controller('promotions')
 export class PromotionController {
   constructor(private readonly promotionService: PromotionService) {}

--- a/src/business/controllers/reminder.controller.ts
+++ b/src/business/controllers/reminder.controller.ts
@@ -11,13 +11,14 @@ import { ReminderService } from '../services/reminder.service';
 import { SendReminderDto } from '../dtos/requests/Reminder.dto';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/middleware/jwt-auth.guard';
+import { RolesGuard } from 'src/middleware/roles.guard';
 import { Role } from 'src/middleware/role.enum';
 import { Roles } from 'src/middleware/roles.decorator';
 
 @ApiTags('Business Reminder')
 @ApiBearerAuth('access-token')
-// @UseGuards(JwtAuthGuard, RolesGuard)
-// @Roles(Role.Merchant, Role.Staff)
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Merchant, Role.Staff)
 @Controller('reminders')
 export class ReminderController {
   constructor(private readonly reminderService: ReminderService) {}

--- a/src/business/controllers/review.controller.ts
+++ b/src/business/controllers/review.controller.ts
@@ -14,13 +14,14 @@ import { ReviewService } from '../services/review.service';
 import { ReviewResponseDto } from '../dtos/requests/ReviewDto';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/middleware/jwt-auth.guard';
+import { RolesGuard } from 'src/middleware/roles.guard';
 import { Role } from 'src/middleware/role.enum';
 import { Roles } from 'src/middleware/roles.decorator';
 
 @ApiTags('Business Promotion Message')
 @ApiBearerAuth('access-token')
-// @UseGuards(JwtAuthGuard, RolesGuard)
-// @Roles(Role.Merchant, Role.Staff)
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Merchant, Role.Staff)
 @Controller('reviews')
 export class ReviewController {
   constructor(private readonly reviewService: ReviewService) {}

--- a/src/business/controllers/wallet.controller.ts
+++ b/src/business/controllers/wallet.controller.ts
@@ -22,13 +22,14 @@ import {
 import { BusinessWalletService } from '../services/wallet.service';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/middleware/jwt-auth.guard';
+import { RolesGuard } from 'src/middleware/roles.guard';
 import { Role } from 'src/middleware/role.enum';
 import { Roles } from 'src/middleware/roles.decorator';
 
 @ApiTags('Business Wallet')
 @ApiBearerAuth('access-token')
-// @UseGuards(JwtAuthGuard, RolesGuard)
-// @Roles(Role.Merchant, Role.Staff)
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Merchant, Role.Staff)
 @Controller('business-wallet')
 export class BusinessWalletController {
   constructor(private readonly walletService: BusinessWalletService) {}

--- a/src/user/controllers/booking.controller.ts
+++ b/src/user/controllers/booking.controller.ts
@@ -15,9 +15,8 @@ import { JwtAuthGuard } from 'src/middleware/jwt-auth.guard';
 
 @ApiTags('Bookings')
 @ApiBearerAuth('access-token')
-//  @UseGuards(JwtAuthGuard, RolesGuard)
- @UseGuards(JwtAuthGuard)
-// @Roles(Role.Customer)
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Customer)
 @Controller('/bookings')
 export class BookingController {
   constructor(private bookingService: BookingService) {}

--- a/test/auth-guards.e2e-spec.ts
+++ b/test/auth-guards.e2e-spec.ts
@@ -1,0 +1,128 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+/**
+ * DEV-051: Auth guard restoration e2e tests.
+ *
+ * Verifies that each previously-unguarded controller now rejects unauthenticated
+ * requests with 401. A 401 proves JwtAuthGuard is active; before DEV-051 these
+ * routes were fully open.
+ *
+ * Run with: NODE_ENV=test npm run test:e2e -- --testPathPattern=auth-guards
+ */
+
+describe('Auth Guards (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    await app.init();
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  function get(path: string) {
+    return request(app.getHttpServer()).get(path);
+  }
+
+  function post(path: string, body: Record<string, unknown> = {}) {
+    return request(app.getHttpServer()).post(path).send(body);
+  }
+
+  // ── Business Wallet ──────────────────────────────────────────────────────────
+  describe('BusinessWalletController — GET /api/business-wallet/wallet', () => {
+    it('returns 401 without a token', async () => {
+      const res = await get('/api/business-wallet/wallet');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── Reviews ──────────────────────────────────────────────────────────────────
+  describe('ReviewController — GET /api/reviews/client/:clientId', () => {
+    it('returns 401 without a token', async () => {
+      const res = await get('/api/reviews/client/some-id');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── Reminders ────────────────────────────────────────────────────────────────
+  describe('ReminderController — POST /api/reminders/send', () => {
+    it('returns 401 without a token', async () => {
+      const res = await post('/api/reminders/send', {});
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── Promotions ───────────────────────────────────────────────────────────────
+  describe('PromotionController — POST /api/promotions/send', () => {
+    it('returns 401 without a token', async () => {
+      const res = await post('/api/promotions/send', {});
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── Custom Messages ──────────────────────────────────────────────────────────
+  describe('CustomMessageController — POST /api/custom-messages/send-email', () => {
+    it('returns 401 without a token', async () => {
+      const res = await post('/api/custom-messages/send-email', {});
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── Communications ───────────────────────────────────────────────────────────
+  describe('CommunicationController — POST /api/communications/send-direct-message', () => {
+    it('returns 401 without a token', async () => {
+      const res = await post('/api/communications/send-direct-message', {});
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── Clients ──────────────────────────────────────────────────────────────────
+  describe('ClientController — GET /api/clients', () => {
+    it('returns 401 without a token', async () => {
+      const res = await get('/api/clients');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── Business Settings ────────────────────────────────────────────────────────
+  describe('BusinessSettingsController — GET /api/business-settings/profile', () => {
+    it('returns 401 without a token', async () => {
+      const res = await get('/api/business-settings/profile');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── Business Owner Settings ──────────────────────────────────────────────────
+  describe('BusinessOwnerSettingsController — GET /api/business-owner-settings/owner', () => {
+    it('returns 401 without a token', async () => {
+      const res = await get('/api/business-owner-settings/owner');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── Business Gift Cards ──────────────────────────────────────────────────────
+  describe('BusinessGiftCardsController — GET /api/business-gift-cards/list', () => {
+    it('returns 401 without a token', async () => {
+      const res = await get('/api/business-gift-cards/list');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── Bookings ─────────────────────────────────────────────────────────────────
+  describe('BookingController — GET /api/bookings/me', () => {
+    it('returns 401 without a token', async () => {
+      const res = await get('/api/bookings/me');
+      expect(res.status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
 Restore commented-out auth guards across business and user controllers
    - Uncommented `@UseGuards(JwtAuthGuard, RolesGuard)` and `@Roles(Role.Merchant, Role.Staff)` on 10 business controllers: wallet,
  review, reminder, promotion, custom-message, communication, client, business-settings, business-owner-settings, business-giftcard
    - Added missing `RolesGuard` import to 9 of those controllers
    - Upgraded `booking.controller.ts` from partial `@UseGuards(JwtAuthGuard)` to full `@UseGuards(JwtAuthGuard, RolesGuard)` +
  `@Roles(Role.Customer)`
    - Removed stale duplicate `// @UseGuards(JwtAuthGuard)` comment in communication controller
    - Added e2e tests verifying all 11 controllers return 401 on unauthenticated requests

  ## Test plan
  - Run `npx jest --config ./test/jest-e2e.json --runInBand test/auth-guards.e2e-spec.ts`
  - Business endpoints (e.g. `/clients`, `/reminders`, `/promotions`) return 401 without a token
  -  Business endpoints return 403 with a valid customer token (wrong role)
  - Business endpoints return 200 with a valid merchant/staff token
  - `/bookings/me` returns 403 with a merchant token