### PR TITLE
  DEV-054 - KAYODE - 05 JUL 2026                            

### DIFF
--- a/src/business/controllers/client.controller.ts
+++ b/src/business/controllers/client.controller.ts
@@ -803,6 +803,8 @@ export class ClientController {
   async getEmergencyContacts(
     @Request() req,
     @Param('clientId') clientId: string,
+    @Query('page') page = 1,
+    @Query('limit') limit = 10,
   ) {
     const ownerId = req.user._id || req.user.userId;
     if (!ownerId) {
@@ -815,6 +817,8 @@ export class ClientController {
     const result = await this.emergencyContactService.getEmergencyContacts(
       clientId,
       ownerId,
+      Number(page),
+      Number(limit),
     );
 
     if (!result.success) {

--- a/src/business/services/emergency-contact.service.ts
+++ b/src/business/services/emergency-contact.service.ts
@@ -83,9 +83,10 @@ export class EmergencyContactService {
   async getEmergencyContacts(
     clientId: string,
     ownerId: string,
-  ): Promise<ApiResponse<EmergencyContact[]>> {
+    page: number = 1,
+    limit: number = 10,
+  ): Promise<ApiResponse<{ contacts: EmergencyContact[]; total: number; page: number; limit: number; totalPages: number }>> {
     try {
-      // Verify client belongs to owner
       const client = await this.clientRepo.findOne({
         where: {
           id: clientId,
@@ -102,13 +103,22 @@ export class EmergencyContactService {
         };
       }
 
-      const contacts = await this.emergencyContactRepo.findBy({
-        clientId,
+      const [contacts, total] = await this.emergencyContactRepo.findAndCount({
+        where: { clientId },
+        skip: (page - 1) * limit,
+        take: limit,
+        order: { createdAt: 'DESC' },
       });
 
       return {
         success: true,
-        data: contacts,
+        data: {
+          contacts,
+          total,
+          page,
+          limit,
+          totalPages: Math.ceil(total / limit),
+        },
         message: 'Emergency contacts retrieved successfully',
       };
     } catch (error) {


### PR DESCRIPTION
Add pagination to emergency contact records endpoint
    - `GET /clients/client/:clientId/emergency-contacts` now accepts `?page=1&limit=10` query params
    - Service updated to use `findAndCount` with `skip`/`take` instead of returning all records
    - Response `data` now returns `{ contacts, total, page, limit, totalPages }` instead of a flat array

   Test plan
  - `GET /clients/client/:clientId/emergency-contacts` returns 200 with pagination metadata
  - `?page=1&limit=1` returns first contact only
  - `?page=2&limit=1` returns second contact only
  - Response shape includes `total`, `page`, `limit`, `totalPages`