### PR TITLE
  DEV-057 - KAYODE - 05 JUL 2026                            

### DIFF
--- a/src/business/dtos/requests/ClientDto.ts
+++ b/src/business/dtos/requests/ClientDto.ts
@@ -9,6 +9,7 @@ import {
   MinLength,
   IsNumber,
   Min,
+  IsIn,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ClientSource, Pronouns, ClientType } from 'src/business/entities/client.entity';
@@ -312,6 +313,7 @@ export class ClientFiltersDto {
   clientType?: ClientType;
 
   @IsOptional()
+  @IsIn(['createdAt', 'firstName', 'lastName', 'email', 'phone', 'updatedAt'])
   sortBy?: string;
 
   @IsOptional()

--- a/src/business/services/client.service.ts
+++ b/src/business/services/client.service.ts
@@ -503,11 +503,11 @@ export class ClientService {
         });
       }
 
-      // Sorting
-      const sortColumn =
-        sortBy === 'createdAt' ? 'client.createdAt' : `client.${sortBy}`;
+      // Sorting — allowlist prevents column name injection
+      const ALLOWED_SORT_COLUMNS = new Set(['createdAt', 'firstName', 'lastName', 'email', 'phone', 'updatedAt']);
+      const safeSortBy = ALLOWED_SORT_COLUMNS.has(sortBy) ? sortBy : 'createdAt';
       queryBuilder.orderBy(
-        sortColumn,
+        `client.${safeSortBy}`,
         sortOrder.toUpperCase() as 'ASC' | 'DESC',
       );
 

--- a/src/business/tests/client.service.sortby.spec.ts
+++ b/src/business/tests/client.service.sortby.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * DEV-057: sortBy allowlist unit tests.
+ *
+ * Tests the allowlist logic in isolation — no DB, no NestJS context.
+ * Mirrors the exact logic in client.service.ts getClients().
+ */
+
+const ALLOWED_SORT_COLUMNS = new Set([
+  'createdAt',
+  'firstName',
+  'lastName',
+  'email',
+  'phone',
+  'updatedAt',
+]);
+
+function resolveSortColumn(sortBy: string | undefined): string {
+  const safe = sortBy && ALLOWED_SORT_COLUMNS.has(sortBy) ? sortBy : 'createdAt';
+  return `client.${safe}`;
+}
+
+describe('DEV-057 — sortBy allowlist', () => {
+  describe('valid sortBy values', () => {
+    const allowed = ['createdAt', 'firstName', 'lastName', 'email', 'phone', 'updatedAt'];
+
+    allowed.forEach((col) => {
+      it(`accepts "${col}" → client.${col}`, () => {
+        expect(resolveSortColumn(col)).toBe(`client.${col}`);
+      });
+    });
+  });
+
+  describe('invalid / malicious sortBy values', () => {
+    const cases: Array<[string, string | undefined]> = [
+      ['SQL injection payload', "id; DROP TABLE clients--"],
+      ['DELETE injection', "'; DELETE FROM clients WHERE '1'='1"],
+      ['path traversal attempt', '../../../etc/passwd'],
+      ['unknown column', 'unknownColumn'],
+      ['empty string', ''],
+      ['undefined', undefined],
+    ];
+
+    cases.forEach(([label, payload]) => {
+      it(`rejects ${label} → falls back to client.createdAt`, () => {
+        expect(resolveSortColumn(payload)).toBe('client.createdAt');
+      });
+    });
+  });
+});


### PR DESCRIPTION
 Fix SQL injection via unsafe sortBy column interpolation
    - `sortBy` query param was interpolated directly into SQL: `client.${sortBy}` — any value passed went straight to the DB
    - Added explicit allowlist in `client.service.ts`: only `createdAt`, `firstName`, `lastName`, `email`, `phone`, `updatedAt` are
  accepted; anything else defaults to `createdAt`
    - Added `@IsIn([...])` validator to `sortBy` in `ClientFiltersDto` as a second layer of defence at the HTTP boundary
    - Added 12 unit tests covering all allowed columns and malicious payloads (SQL injection, DELETE injection, path traversal, unknown
  columns)

  ## Test plan
  - Run `npx jest src/business/tests/client.service.sortby.spec.ts --no-coverage`
  - `GET /clients?sortBy=firstName` sorts correctly
  - `GET /clients?sortBy=id; DROP TABLE clients--` returns 400 (rejected by DTO validation)