### PR TITLE
DEV-082 -ADJ-luxury override logic

### DIFF
--- a/scripts/add-luxury-override-column.ts
+++ b/scripts/add-luxury-override-column.ts
@@ -1,0 +1,28 @@
+import { Client } from 'pg';
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+async function run() {
+  const client = new Client({
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT),
+    user: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_DATABASE,
+  });
+  await client.connect();
+  console.log('Connected to database.');
+
+  await client.query(`
+    ALTER TABLE businesses
+    ADD COLUMN IF NOT EXISTS "luxuryOverride" boolean NULL DEFAULT NULL;
+  `);
+  console.log('luxuryOverride column added (or already existed).');
+
+  await client.end();
+}
+
+run().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/src/admin/services/admin.service.ts
+++ b/src/admin/services/admin.service.ts
@@ -6,6 +6,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { EmailService } from '../../email/email.service';
+import { invalidateCache } from '../../cache/cache.interceptor';
 import { User } from '../../all_user_entities/user.entity';
 import {
   Business,
@@ -445,6 +446,7 @@ export class AdminService {
     business.luxuryOverride = true;
 
     await this.businessRepo.save(business);
+    await invalidateCache('/api/salons');
 
     return { message: `Business has been marked as luxury.` };
   }
@@ -458,6 +460,7 @@ export class AdminService {
     business.luxuryOverride = false;
 
     await this.businessRepo.save(business);
+    await invalidateCache('/api/salons');
 
     return { message: `Business has been removed from luxury.` };
   }

--- a/src/admin/services/admin.service.ts
+++ b/src/admin/services/admin.service.ts
@@ -442,7 +442,7 @@ export class AdminService {
       throw new BadRequestException('Business not found');
     }
 
-    business.isLuxury = true;
+    business.luxuryOverride = true;
 
     await this.businessRepo.save(business);
 
@@ -455,7 +455,7 @@ export class AdminService {
       throw new BadRequestException('Business not found');
     }
 
-    business.isLuxury = false;
+    business.luxuryOverride = false;
 
     await this.businessRepo.save(business);
 

--- a/src/business/entities/business.entity.ts
+++ b/src/business/entities/business.entity.ts
@@ -122,6 +122,9 @@ export class Business {
   @Column({ type: 'boolean', default: false })
   isLuxury: boolean;
 
+  @Column({ type: 'boolean', nullable: true, default: null })
+  luxuryOverride: boolean | null;
+
   @Column({ type: 'float', default: 0 })
   revenue: number;
 

--- a/src/cache/cache.interceptor.ts
+++ b/src/cache/cache.interceptor.ts
@@ -120,11 +120,47 @@ export class CacheInterceptor implements NestInterceptor {
 
   private generateCacheKey(request: any): string {
     const { method, originalUrl, query } = request;
+    const path = originalUrl.split('?')[0];
     const sortedQuery = Object.keys(query)
       .sort()
       .map((key) => `${key}=${query[key]}`)
       .join('&');
     const key = `${method}:${originalUrl}?${sortedQuery}`;
-    return crypto.createHash('md5').update(key).digest('hex');
+    const hash = crypto.createHash('md5').update(key).digest('hex');
+    // Keep the plain method+path visible (unhashed) so invalidateCache()
+    // can pattern-match and clear every cached query-variant of a given
+    // route, without needing to know every exact query string that was cached.
+    return `${method}:${path}:${hash}`;
+  }
+}
+
+/**
+ * Deletes every cached entry for a given route path, regardless of which
+ * query-string variant was cached. Used to bust stale responses immediately
+ * after a mutation that should invalidate them (e.g. an admin marking a
+ * business as luxury), rather than waiting out the full CACHE_TTL_SECONDS.
+ */
+export async function invalidateCache(pathPrefix: string): Promise<void> {
+  try {
+    const pattern = `*:${pathPrefix}*`;
+    const stream = redisClient.scanStream({ match: pattern, count: 100 });
+    const keysToDelete: string[] = [];
+
+    for await (const keys of stream) {
+      keysToDelete.push(...keys);
+    }
+
+    if (keysToDelete.length > 0) {
+      await redisClient.unlink(...keysToDelete);
+      logger.log(
+        `Invalidated ${keysToDelete.length} cache key(s) matching ${pathPrefix}`,
+        'CacheInterceptor',
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      `Cache invalidation failed for ${pathPrefix}: ${(err as Error).message}`,
+      'CacheInterceptor',
+    );
   }
 }

--- a/src/user/services/salon.service.ts
+++ b/src/user/services/salon.service.ts
@@ -83,11 +83,14 @@ export class SalonService {
       });
     }
 
-    // Filter by luxury flag
-    // Filter by luxury: either admin-curated OR naturally high-rated (4.5+)
+    // Filter by luxury flag.
+    // Admin decision (luxuryOverride) always wins in either direction.
+    // If the admin hasn't made a decision (luxuryOverride IS NULL),
+    // fall back to automatic rating-based qualification (4.5+).
     if (isLuxury) {
       query = query.andWhere(
-        "(business.isLuxury = true OR CAST(business.performance->>'rating' AS FLOAT) >= 4.5)",
+        `("business"."luxuryOverride" = true OR
+            ("business"."luxuryOverride" IS NULL AND CAST(business.performance->>'rating' AS FLOAT) >= 4.5))`,
       );
     }
     // Filter by services (array in text column)


### PR DESCRIPTION
Title: Fix: luxury flag admin override + cache invalidation
Description:
Two related fixes for the luxury/VIP salon feature:

Admin override logic — Previously, luxury status used OR logic (isLuxury = true OR rating >= 4.5), meaning an admin could never actually remove a high-rated business from the luxury list — the rating alone would always keep it showing regardless of the admin's decision. Added a new luxuryOverride field (true/false/null) so an explicit admin decision always wins in either direction. Falls back to automatic rating-based qualification only when the admin hasn't made a decision (luxuryOverride IS NULL).
Cache invalidation — The customer-facing salon listing is cached in Redis for 5 minutes. Admin luxury changes weren't reflected until that cache naturally expired. Added an invalidateCache() helper (cache keys now retain a readable route prefix instead of being purely an MD5 hash) and call it after every luxury status change, so updates show immediately.

Testing: Verified locally — marking/unmarking luxury status now updates the customer-facing listing instantly, and admin decisions correctly override rating-based auto-qualification in both directions.