### PR TITLE
Divine/rem 008 backend service location endpoints

### DIFF
--- a/src/user/controllers/salon.controller.ts
+++ b/src/user/controllers/salon.controller.ts
@@ -87,6 +87,30 @@ export class SalonController {
   }
 
   @Public()
+  @Get('service-types')
+  @ApiOperation({
+    summary: 'Get all programmatic service types with value and label',
+  })
+  @ApiResponse({ status: 200, description: 'Return list of service types' })
+  async getServiceTypes() {
+    return this.salonService.getServiceTypes();
+  }
+
+  @Public()
+  @Get('locations')
+  @ApiOperation({
+    summary:
+      'Get list of distinct city/location values from approved businesses',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Return list of unique locations/cities',
+  })
+  async getLocations() {
+    return this.salonService.getLocations();
+  }
+
+  @Public()
   @Get('services/:businessId')
   @ApiOperation({ summary: 'Get all services for a business by business ID' })
   @ApiResponse({ status: 200, description: 'Return list of services' })

--- a/src/user/controllers/salon.controller.ts
+++ b/src/user/controllers/salon.controller.ts
@@ -18,6 +18,30 @@ import { CacheInterceptor } from '../../cache/cache.interceptor';
 export class SalonController {
   constructor(private readonly salonService: SalonService) {}
 
+  @Public()
+  @Get('service-types')
+  @ApiOperation({
+    summary: 'Get all programmatic service types with value and label',
+  })
+  @ApiResponse({ status: 200, description: 'Return list of service types' })
+  async getServiceTypes() {
+    return this.salonService.getServiceTypes();
+  }
+
+  @Public()
+  @Get('locations')
+  @ApiOperation({
+    summary:
+      'Get list of distinct city/location values from approved businesses',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Return list of unique locations/cities',
+  })
+  async getLocations() {
+    return this.salonService.getLocations();
+  }
+
   @Get()
   @ApiOperation({ summary: 'Get all salons with pagination and filters' })
   @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
@@ -84,30 +108,6 @@ export class SalonController {
   })
   async getServices(@Query('category') category?: string) {
     return this.salonService.getServices(category);
-  }
-
-  @Public()
-  @Get('service-types')
-  @ApiOperation({
-    summary: 'Get all programmatic service types with value and label',
-  })
-  @ApiResponse({ status: 200, description: 'Return list of service types' })
-  async getServiceTypes() {
-    return this.salonService.getServiceTypes();
-  }
-
-  @Public()
-  @Get('locations')
-  @ApiOperation({
-    summary:
-      'Get list of distinct city/location values from approved businesses',
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Return list of unique locations/cities',
-  })
-  async getLocations() {
-    return this.salonService.getLocations();
   }
 
   @Public()

--- a/src/user/services/salon.service.ts
+++ b/src/user/services/salon.service.ts
@@ -7,6 +7,7 @@ import {
   Business,
   BusinessStatus,
 } from 'src/business/entities/business.entity';
+import { ServiceType } from 'src/business/types/service-type.enum';
 
 @Injectable()
 export class SalonService {
@@ -107,7 +108,10 @@ export class SalonService {
     switch (sortBy) {
       case 'topRated':
         query = query
-          .orderBy("COALESCE((business.performance->>'rating')::FLOAT, 0)", 'DESC')
+          .orderBy(
+            "COALESCE((business.performance->>'rating')::FLOAT, 0)",
+            'DESC',
+          )
           .addOrderBy('business.revenue', 'DESC');
         break;
 
@@ -125,7 +129,10 @@ export class SalonService {
       case 'bestMatch':
       default:
         query = query
-          .orderBy("COALESCE((business.performance->>'rating')::FLOAT, 0)", 'DESC')
+          .orderBy(
+            "COALESCE((business.performance->>'rating')::FLOAT, 0)",
+            'DESC',
+          )
           .addOrderBy('business.createdAt', 'DESC');
         break;
     }
@@ -175,5 +182,37 @@ export class SalonService {
       where: { business: { id: businessId } },
       relations: ['business'],
     });
+  }
+
+  async getServiceTypes(): Promise<{ value: string; label: string }[]> {
+    return Object.values(ServiceType).map((value) => {
+      const label = value
+        .split('-')
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
+      return { value, label };
+    });
+  }
+
+  async getLocations(): Promise<string[]> {
+    const businesses = await this.businessRepository
+      .createQueryBuilder('business')
+      .select('DISTINCT business.businessAddress', 'address')
+      .where('business.status = :status', { status: BusinessStatus.APPROVED })
+      .getRawMany();
+
+    const locations = Array.from(
+      new Set(
+        businesses
+          .map((b) => {
+            const addr = b.address || '';
+            const parts = addr.split(',');
+            return parts[parts.length - 1]?.trim() || '';
+          })
+          .filter((loc) => loc.length > 0),
+      ),
+    );
+
+    return locations.sort();
   }
 }


### PR DESCRIPTION
## Summary
Adds two new public read-only endpoints to support frontend service/location 
filtering and autocomplete (this backend if for frontend REM-008, REM-059, REM-064 frontend follow-ups):
- GET /api/salons/service-types — returns { value, label } list generated 
  programmatically from the ServiceType enum
- GET /api/salons/locations — returns distinct city names parsed from approved 
  businesses' businessAddress field

## Changes
- src/user/services/salon.service.ts: added getServiceTypes() and getLocations()
- src/user/controllers/salon.controller.ts: added service-types and locations 
  routes, placed above the existing :id route to avoid NestJS route-matching 
  conflicts (locations was initially being caught by @Get(':id') and passed to 
  Postgres as a UUID, causing a query error — fixed by reordering)

## The limitation
Business schema has no dedicated city/region column. getLocations() parses the 
city as the last comma-separated segment of businessAddress (e.g. "12 Wuse 2, 
Abuja, Abuja" → "Abuja"). This is a stopgap — relies on addresses consistently 
ending in ", <City>" and should be replaced with a structured location field 
on the Business entity when available.

## Testing
Verified locally — both endpoints return real data:
- /api/salons/service-types: 25 service types with clean labels
- /api/salons/locations: ["Abuja", "Ibadan", "Kano", "Lagos", "Port Harcourt"]

## Scope
No changes to existing GET /salons filtering logic or the ServiceType enum 
itself. No auth changes beyond matching existing @Public() pattern used elsewhere.