### PR TITLE
rem 064,074 - ADJ -  backend service filter fix

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,10 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
   app.useLogger(logger);
 
+  // Configure Express to use the 'extended' query parser (qs library)
+  // to support bracket-notation array params like services[]=x
+  app.getHttpAdapter().getInstance().set('query parser', 'extended');
+
   app.use(express.json({ limit: '10mb' }));
   app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 

--- a/src/user/controllers/salon.controller.ts
+++ b/src/user/controllers/salon.controller.ts
@@ -74,6 +74,8 @@ export class SalonController {
   })
   @ApiQuery({ name: 'lat', required: false, type: Number, example: -33.8688 })
   @ApiQuery({ name: 'lng', required: false, type: Number, example: 151.2093 })
+  @ApiQuery({ name: 'date', required: false, type: String, example: '2026-07-14' })
+  @ApiQuery({ name: 'time', required: false, type: String, example: '14:30' })
   @ApiResponse({ status: 200, description: 'Return list of salons' })
   @UseInterceptors(CacheInterceptor) //  Apply caching
   @Public()
@@ -93,6 +95,8 @@ export class SalonController {
       sortBy: query.sortBy || 'bestMatch',
       lat: query.lat ? parseFloat(query.lat) : undefined,
       lng: query.lng ? parseFloat(query.lng) : undefined,
+      date: query.date || '',
+      time: query.time || '',
     };
 
     return this.salonService.findAll(options);

--- a/src/user/services/salon.service.spec.ts
+++ b/src/user/services/salon.service.spec.ts
@@ -1,0 +1,40 @@
+import { SalonService } from './salon.service';
+
+describe('SalonService', () => {
+  it('filters salons by booking hours when date and time are provided', async () => {
+    const queryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    };
+
+    const businessRepo = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    } as any;
+
+    const serviceRepo = {
+      find: jest.fn().mockResolvedValue([]),
+    } as any;
+
+    const service = new SalonService(businessRepo, serviceRepo);
+
+    await service.findAll({ date: '2026-07-14', time: '14:30' });
+
+    const conditions = queryBuilder.andWhere.mock.calls.map(([sql]) => sql);
+
+    expect(conditions).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('bookingHours.day = :day'),
+        expect.stringContaining('bookingHours.isOpen = :isOpen'),
+        expect.stringContaining('bookingHours.startTime <= :time'),
+        expect.stringContaining('bookingHours.endTime >= :time'),
+      ]),
+    );
+  });
+});

--- a/src/user/services/salon.service.ts
+++ b/src/user/services/salon.service.ts
@@ -95,12 +95,19 @@ export class SalonService {
             ("business"."luxuryOverride" IS NULL AND COALESCE((business.performance->>'rating')::FLOAT, 0) >= 4.5))`,
       );
     }
-    // Filter by services (array in text column)
+    // Filter by services using the real Service relation
     if (services.length > 0) {
       services.forEach((service, index) => {
-        query = query.andWhere(`:service${index} = ANY(business.service)`, {
-          [`service${index}`]: service,
-        });
+        query = query.leftJoinAndSelect(
+          'business.serviceList',
+          `serviceList${index}`,
+        );
+        query = query.andWhere(
+          `serviceList${index}.serviceType = :service${index}`,
+          {
+            [`service${index}`]: service,
+          },
+        );
       });
     }
 

--- a/src/user/services/salon.service.ts
+++ b/src/user/services/salon.service.ts
@@ -98,7 +98,7 @@ export class SalonService {
     // Filter by services (array in text column)
     if (services.length > 0) {
       services.forEach((service, index) => {
-        query = query.andWhere(`:service${index} = ANY(business.services)`, {
+        query = query.andWhere(`:service${index} = ANY(business.service)`, {
           [`service${index}`]: service,
         });
       });

--- a/src/user/services/salon.service.ts
+++ b/src/user/services/salon.service.ts
@@ -1,6 +1,16 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
+
+const WEEKDAY_NAMES = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+] as const;
 
 import { Service } from 'src/business/entities/service.entity';
 import {
@@ -30,6 +40,8 @@ export class SalonService {
     lat?: number;
     lng?: number;
     category?: string;
+    date?: string;
+    time?: string;
   }): Promise<{
     data: Business[];
     total: number;
@@ -48,6 +60,8 @@ export class SalonService {
       lat,
       lng,
       category,
+      date,
+      time,
     } = options;
 
     let query = this.businessRepository
@@ -98,10 +112,7 @@ export class SalonService {
     // Filter by services using the real Service relation
     if (services.length > 0) {
       services.forEach((service, index) => {
-        query = query.leftJoinAndSelect(
-          'business.serviceList',
-          `serviceList${index}`,
-        );
+        query = query.leftJoin('business.serviceList', `serviceList${index}`);
         query = query.andWhere(
           `serviceList${index}.serviceType = :service${index}`,
           {
@@ -111,14 +122,28 @@ export class SalonService {
       });
     }
 
+    if (date) {
+      const parsedDate = new Date(date);
+      const day = WEEKDAY_NAMES[parsedDate.getUTCDay()];
+
+      query = query.leftJoin('business.bookingHours', 'bookingHours');
+      query = query.andWhere('bookingHours.day = :day', { day });
+      query = query.andWhere('bookingHours.isOpen = :isOpen', { isOpen: true });
+
+      if (time) {
+        query = query.andWhere('bookingHours.startTime <= :time', { time });
+        query = query.andWhere('bookingHours.endTime >= :time', { time });
+      }
+    }
+
     // Apply sorting
+    const ratingExpression =
+      "COALESCE((business.performance->>'rating')::FLOAT, 0)";
     switch (sortBy) {
       case 'topRated':
+        query = query.addSelect(ratingExpression, 'rating');
         query = query
-          .orderBy(
-            "COALESCE((business.performance->>'rating')::FLOAT, 0)",
-            'DESC',
-          )
+          .orderBy('rating', 'DESC')
           .addOrderBy('business.revenue', 'DESC');
         break;
 
@@ -135,11 +160,9 @@ export class SalonService {
 
       case 'bestMatch':
       default:
+        query = query.addSelect(ratingExpression, 'rating');
         query = query
-          .orderBy(
-            "COALESCE((business.performance->>'rating')::FLOAT, 0)",
-            'DESC',
-          )
+          .orderBy('rating', 'DESC')
           .addOrderBy('business.createdAt', 'DESC');
         break;
     }
@@ -154,7 +177,10 @@ export class SalonService {
     // Load services separately to avoid join issues with pagination
     for (const business of data) {
       business.serviceList = await this.serviceRepo.find({
-        where: { business: { id: business.id } },
+        where: {
+          business: { id: business.id },
+          ...(services.length > 0 ? { serviceType: In(services) } : {}),
+        },
       });
     }
 


### PR DESCRIPTION
## Summary
Fixes GET /salons service filtering (was silently broken end-to-end despite 
looking functional) and adds date/time open-hours filtering.

## Bugs found and fixed (services filter)
1. Column name typo: query referenced business.services (plural), actual 
   column is business.service (singular) — caused a 500 whenever the filter 
   clause executed

2. Bracket-array param parsing: frontend sends services[]=x, but Express's 
   default query parser didn't resolve this to an array — silently dropped 
   the filter and returned unfiltered results instead of erroring. Fixed by 
   setting Express's query parser to 'extended'.

3. Wrong data source: filter was querying the legacy, disconnected 
   business.service column instead of the real Service entity relation 
   (serviceList.serviceType) — 80 seeded businesses had real services but 
   empty business.service arrays. Fixed to filter against serviceList directly.

4. Post-query reload bug: after filtering, a separate loop reloaded ALL 
   services for each matching business with no service-type condition, 
   silently discarding the filter's results. Fixed to reload only matching 
   serviceType.

## New feature
REM-074 — Added optional date/time params to GET /salons, filtering to 
businesses open on that day/time using the existing bookingHours relation 
(day, isOpen, startTime, endTime). Does not check actual appointment slot 
availability — that's out of scope, tracked separately if needed.

## Known limitation (flagged, not fixed here)
business.service is a legacy field disconnected from real Service entity 
CRUD — updated only via a separate business-settings save flow, not kept in 
sync automatically. ~80 businesses currently affected. Recommend a separate 
ticket for whoever owns the business-settings/entity design to either 
deprecate this column or wire it to stay in sync.

## Testing
- GET /api/salons?services[]=women-haircut&location=Lagos returns only 
  matching services for matching businesses (previously returned everything, 
  unfiltered)
- GET /api/salons?date=2026-07-14&time=11:00 vs. time=23:00 on the same date 
  returns different totals (10 vs. 0), confirming the time-window logic 
  works, not just day-of-week
- No regressions to /api/salons/service-types or /api/salons/locations