### PR TITLE
REM-127,REM-139 - KAYODE - 15 Jul 2026

### DIFF
--- a/src/user/controllers/booking.controller.ts
+++ b/src/user/controllers/booking.controller.ts
@@ -1,4 +1,4 @@
-﻿import { Controller, Post, Body, Get, Param, Patch, UseGuards } from '@nestjs/common';
+﻿import { Controller, Post, Body, Get, Param, Patch, UseGuards, BadRequestException } from '@nestjs/common';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { Role } from 'src/middleware/role.enum';
@@ -131,7 +131,10 @@ export class BookingController {
     @Param('orderId') orderId: string,
     @Body() body: { date: string; time: string },
   ) {
-    return this.bookingService.rescheduleBooking(orderId, new Date(body.date), body.time);
+    if (!body.date || isNaN(new Date(body.date).getTime())) {
+      throw new BadRequestException('Invalid or missing date value');
+    }
+    return this.bookingService.rescheduleBooking(orderId, body.date, body.time);
   }
 
   // (Existing) Get salon time slots (static example)

--- a/src/user/services/booking.service.ts
+++ b/src/user/services/booking.service.ts
@@ -749,7 +749,7 @@ export class BookingService {
   }
 
   // Reschedule Booking
-  async rescheduleBooking(orderId: string, newDate: Date, newTime: string): Promise<{ message: string }> {
+  async rescheduleBooking(orderId: string, newDate: string, newTime: string): Promise<{ message: string }> {
     const appointment = await this.bookingRepository.findOne({
       where: { orderId },
       relations: ['client'],
@@ -757,7 +757,7 @@ export class BookingService {
     if (!appointment) {
       throw new NotFoundException('Appointment not found');
     }
-    const formattedDate = newDate.toISOString().split('T')[0];
+    const formattedDate = newDate.split('T')[0];
     appointment.date = formattedDate;
     appointment.time = newTime;
     appointment.status = AppointmentStatus.RESCHEDULED;

--- a/src/user/services/booking.service.ts
+++ b/src/user/services/booking.service.ts
@@ -731,20 +731,21 @@ export class BookingService {
 
   // Restore Cancelled Booking
   async restoreBooking(orderId: string): Promise<{ message: string }> {
-    const appointment = await this.bookingRepository.findOne({
-      where: { orderId },
+    const cancelled = await this.bookingRepository.find({
+      where: { orderId, status: AppointmentStatus.CANCELLED },
     });
-    if (!appointment) {
-      throw new NotFoundException('Appointment not found');
-    }
 
-    if (appointment.status !== AppointmentStatus.CANCELLED) {
+    if (!cancelled.length) {
+      const exists = await this.bookingRepository.findOne({ where: { orderId } });
+      if (!exists) throw new NotFoundException('Appointment not found');
       throw new BadRequestException('Appointment is not cancelled, cannot restore');
     }
 
-    appointment.status = AppointmentStatus.CONFIRMED; // Restore to confirmed status
-    appointment.cancellationsNote = undefined; // Clear cancellation note on restore
-    await this.bookingRepository.save(appointment);
+    for (const appt of cancelled) {
+      appt.status = AppointmentStatus.CONFIRMED;
+      appt.cancellationsNote = undefined;
+    }
+    await this.bookingRepository.save(cancelled);
     return { message: 'Appointment restored successfully' };
   }
 


### PR DESCRIPTION
- REM-127: Fix BE RangeError: Invalid time value in rescheduleBooking — accept date as string instead of Date, validate in
  controller before passing to service                                                                                            
  - Fix cancel toast crash — add optional chaining to booking.store.ts formatBooking() so null business/service relations don't
  throw
  - Fix Ticket ID display — AppointmentCard falls back to ticketId only when orderId is null