### PR TITLE
Rem 420 -ADJ - services page category delete 16/07/2026

### DIFF
--- a/src/business/services/business.service.ts
+++ b/src/business/services/business.service.ts
@@ -39,7 +39,7 @@ import { BusinessWalletService } from './wallet.service';
 import { MailchimpService } from 'src/integration/services/mailchimp.service';
 import { BusinessOwnerSettingsService } from './business-owner-settings.service';
 import { ZohoBooksService } from 'src/integration/services/zohobooks.service';
-import {PasswordUtil} from "../utils/password.util";
+import { PasswordUtil } from '../utils/password.util';
 import { promises } from 'dns';
 
 @Injectable()
@@ -370,8 +370,8 @@ export class BusinessService {
   }
 
   async addStaff(
-      ownerMail: string,
-      createStaffDto: CreateStaffDto,
+    ownerMail: string,
+    createStaffDto: CreateStaffDto,
   ): Promise<Staff> {
     const {
       addresses,
@@ -409,14 +409,16 @@ export class BusinessService {
     // If user already exists, check if they're already staff at this business
     if (user) {
       const existingStaff = await this.staffRepo.findOne({
-        where: { 
+        where: {
           email: staffEmail,
-          business: { id: business.id }
+          business: { id: business.id },
         },
       });
 
       if (existingStaff) {
-        throw new BadRequestException('This user is already a staff member at your business');
+        throw new BadRequestException(
+          'This user is already a staff member at your business',
+        );
       }
     }
 
@@ -430,20 +432,20 @@ export class BusinessService {
       user.phoneNumber = phoneNumber;
       if (gender) user.gender = gender.toUpperCase() as any;
       if (avatar) user.avatarUrl = avatar;
-      
+
       // Business staff are merchants
       user.isMerchant = true;
       user.isCustomer = false;
       user.isStaff = false;
-      
+
       await this.userRepo.save(user);
     } else {
       // Email does not exist - create new user with password
       // Generate strong random password
       tempPassword =
-          Math.random().toString(36).slice(-10) +
-          Math.random().toString(36).toUpperCase().slice(-4) +
-          ['!', '@', '#'][Math.floor(Math.random() * 3)];
+        Math.random().toString(36).slice(-10) +
+        Math.random().toString(36).toUpperCase().slice(-4) +
+        ['!', '@', '#'][Math.floor(Math.random() * 3)];
 
       const hashedPassword = await this.passwordUtil.hashPassword(tempPassword);
 
@@ -465,10 +467,10 @@ export class BusinessService {
 
       try {
         await this.emailService.sendStaffWelcomeEmail(
-            staffEmail,
-            firstName,
-            business.businessName,
-            tempPassword
+          staffEmail,
+          firstName,
+          business.businessName,
+          tempPassword,
         );
       } catch (emailError) {
         console.error('Failed to send welcome email:', emailError);
@@ -504,7 +506,7 @@ export class BusinessService {
       staff.addresses = await this.addressRepo.save(cleanAddresses);
     }
 
-    // Handle assigned services 
+    // Handle assigned services
     if (selectedServices?.length) {
       staff.services = await this.serviceRepo.findByIds(selectedServices);
       await this.staffRepo.save(staff);
@@ -514,7 +516,6 @@ export class BusinessService {
   }
 
   async editStaff(staffId: string, editStaffDto: EditStaffDto): Promise<Staff> {
-
     const staff = await this.staffRepo.findOne({
       where: { id: staffId },
       relations: ['addresses', 'emergencyContacts'],
@@ -526,7 +527,9 @@ export class BusinessService {
 
     // Ensure user record stays as merchant when staff is edited
     if (staff.email) {
-      const user = await this.userRepo.findOne({ where: { email: staff.email } });
+      const user = await this.userRepo.findOne({
+        where: { email: staff.email },
+      });
       if (user && !user.isMerchant) {
         user.isMerchant = true;
         user.isCustomer = false;
@@ -556,7 +559,7 @@ export class BusinessService {
       staff.emergencyContacts = newContacts;
     }
 
-    if(editStaffDto.settings){
+    if (editStaffDto.settings) {
       staff.settings = editStaffDto.settings;
     }
 
@@ -571,14 +574,18 @@ export class BusinessService {
     return staff;
   }
 
-  async getBusinessFromStaff(mail:string){
+  async getBusinessFromStaff(mail: string) {
     const staff = await this.staffRepo.findOne({
-      where:{email:mail},
-      relations: ['business','business.serviceList'],
-    })
+      where: { email: mail },
+      relations: ['business', 'business.serviceList'],
+    });
 
-   if (!staff) {throw new Error('No staff found')}
-   if(!staff.business){throw new Error("business not found")}
+    if (!staff) {
+      throw new Error('No staff found');
+    }
+    if (!staff.business) {
+      throw new Error('business not found');
+    }
 
     return staff.business;
   }
@@ -587,8 +594,8 @@ export class BusinessService {
     let business = await this.businessRepo.findOne({
       where: { ownerEmail: body.ownerMail },
     });
-    if(!body.ownerMail) throw new Error('Invalid User')
-    if(!business) business = await this.getBusinessFromStaff(body.ownerMail)
+    if (!body.ownerMail) throw new Error('Invalid User');
+    if (!business) business = await this.getBusinessFromStaff(body.ownerMail);
     if (!business) throw new NotFoundException('Business not found');
 
     const blockedSlot = this.blockedSlotRepo.create({
@@ -614,8 +621,8 @@ export class BusinessService {
     let business = await this.businessRepo.findOne({
       where: { ownerEmail: userMail },
     });
-    if(!userMail) throw new Error('Invalid User')
-    if(!business) business = await this.getBusinessFromStaff(userMail)
+    if (!userMail) throw new Error('Invalid User');
+    if (!business) business = await this.getBusinessFromStaff(userMail);
     if (!business) throw new NotFoundException('Business not found');
 
     const blockedSlots = await this.blockedSlotRepo.find({
@@ -787,8 +794,8 @@ export class BusinessService {
       relations: ['serviceList'],
     });
 
-    if(!userMail) throw new Error('Invalid User')
-    if(!business) business = await this.getBusinessFromStaff(userMail)
+    if (!userMail) throw new Error('Invalid User');
+    if (!business) business = await this.getBusinessFromStaff(userMail);
     if (!business) {
       throw new NotFoundException('Business not found');
     }
@@ -800,8 +807,8 @@ export class BusinessService {
     let business = await this.businessRepo.findOne({
       where: { ownerEmail: userMail },
     });
-    if(!userMail) throw new Error('Invalid User')
-    if(!business) business = await this.getBusinessFromStaff(userMail)
+    if (!userMail) throw new Error('Invalid User');
+    if (!business) business = await this.getBusinessFromStaff(userMail);
     if (!business) {
       throw new NotFoundException('Business not found');
     }
@@ -817,7 +824,7 @@ export class BusinessService {
 
   async getAdvertisementPlans() {
     const plans = await this.advertisementPlanRepo.find();
-    
+
     // If no advertisement plans exist, seed with default plans
     if (plans.length === 0) {
       const defaultPlans = [
@@ -826,13 +833,10 @@ export class BusinessService {
           price: 69.99,
           durationDays: 30,
           description: 'Basic service promotion',
-          features: [
-            'Featured in search results',
-            'Basic analytics'
-          ],
+          features: ['Featured in search results', 'Basic analytics'],
           payable: 'Basic',
           isRecommended: false,
-          boost: '1.2x'
+          boost: '1.2x',
         },
         {
           planName: 'Premium',
@@ -843,11 +847,11 @@ export class BusinessService {
             'Top placement in search',
             'Detailed analytics',
             'Social media boost',
-            'Priority support'
+            'Priority support',
           ],
           payable: 'Premium',
           isRecommended: true,
-          boost: '2x'
+          boost: '2x',
         },
         {
           planName: 'Elite',
@@ -859,12 +863,12 @@ export class BusinessService {
             'Advanced analytics',
             'Marketing consultation',
             'Cross-platform promotion',
-            'Dedicated support'
+            'Dedicated support',
           ],
           payable: 'Elite',
           isRecommended: false,
-          boost: '3.5x'
-        }
+          boost: '3.5x',
+        },
       ];
 
       const savedPlans = await this.advertisementPlanRepo.save(defaultPlans);
@@ -894,8 +898,8 @@ export class BusinessService {
     let business = await this.businessRepo.findOne({
       where: { ownerEmail: userMail },
     });
-    if(!userMail) throw new Error('Invalid User')
-    if(!business) business = await this.getBusinessFromStaff(userMail)
+    if (!userMail) throw new Error('Invalid User');
+    if (!business) business = await this.getBusinessFromStaff(userMail);
     if (!business) throw new Error('Business not found');
 
     let advertisementPlan: AdvertisementPlan | undefined;
@@ -938,7 +942,7 @@ export class BusinessService {
   async updateService(serviceId: string, updateServiceDto: UpdateServiceDto) {
     const service = await this.serviceRepo.findOne({
       where: { id: serviceId },
-      relations: ['business']
+      relations: ['business'],
     });
 
     if (!service) {
@@ -975,7 +979,7 @@ export class BusinessService {
     const { serviceId } = deleteServiceDto;
 
     const service = await this.serviceRepo.findOne({
-      where: { id: serviceId }
+      where: { id: serviceId },
     });
 
     if (!service) {
@@ -984,11 +988,13 @@ export class BusinessService {
 
     // Check if service has any appointments
     const appointmentCount = await this.appointmentRepo.count({
-      where: { service: { id: serviceId } }
+      where: { service: { id: serviceId } },
     });
 
     if (appointmentCount > 0) {
-      throw new BadRequestException('Cannot delete service that has appointments');
+      throw new BadRequestException(
+        'Cannot delete service that has appointments',
+      );
     }
 
     await this.serviceRepo.remove(service);
@@ -1001,7 +1007,7 @@ export class BusinessService {
     // Find the service
     const service = await this.serviceRepo.findOne({
       where: { id: serviceId },
-      relations: ['business']
+      relations: ['business'],
     });
 
     if (!service) {
@@ -1010,11 +1016,13 @@ export class BusinessService {
 
     // Find all staff members
     const staffMembers = await this.staffRepo.find({
-      where: { id: In(staffIds), business: { id: service.business.id } }
+      where: { id: In(staffIds), business: { id: service.business.id } },
     });
 
     if (staffMembers.length !== staffIds.length) {
-      throw new NotFoundException('One or more staff members not found or do not belong to this business');
+      throw new NotFoundException(
+        'One or more staff members not found or do not belong to this business',
+      );
     }
 
     // Assign staff to service
@@ -1024,7 +1032,7 @@ export class BusinessService {
     return {
       message: 'Staff assigned to service successfully',
       serviceId: service.id,
-      assignedStaffCount: staffMembers.length
+      assignedStaffCount: staffMembers.length,
     };
   }
 
@@ -1035,7 +1043,9 @@ export class BusinessService {
     await this.staffRepo.save(staff);
 
     if (staff.email) {
-      const user = await this.userRepo.findOne({ where: { email: staff.email } });
+      const user = await this.userRepo.findOne({
+        where: { email: staff.email },
+      });
       if (user) {
         user.isMerchant = false;
         user.isCustomer = true;
@@ -1051,10 +1061,13 @@ export class BusinessService {
       where: { owner: { id: userId } },
     });
 
-    if(!business){
-      const staff = await this.staffRepo.findOne({where: { id: userId },relations: ['business']});
-      if(!staff?.business)throw new NotFoundException('Business not found');
-      business = staff?.business
+    if (!business) {
+      const staff = await this.staffRepo.findOne({
+        where: { id: userId },
+        relations: ['business'],
+      });
+      if (!staff?.business) throw new NotFoundException('Business not found');
+      business = staff?.business;
     }
 
     if (!business) {
@@ -1078,10 +1091,13 @@ export class BusinessService {
       where: { owner: { id: userId } },
     });
 
-    if(!business){
-      const staff = await this.staffRepo.findOne({where: { id: userId },relations: ['business']});
-      if(!staff?.business)throw new NotFoundException('Business not found');
-      business = staff?.business
+    if (!business) {
+      const staff = await this.staffRepo.findOne({
+        where: { id: userId },
+        relations: ['business'],
+      });
+      if (!staff?.business) throw new NotFoundException('Business not found');
+      business = staff?.business;
     }
 
     if (!business) {
@@ -1098,8 +1114,6 @@ export class BusinessService {
       },
     });
   }
-
-
 
   getServices(): BusinessServiceData[] {
     return getBusinessServices();
@@ -1154,7 +1168,7 @@ export class BusinessService {
       isMerchant: user.isMerchant,
       isCustomer: user.isCustomer,
       createdAt: user.createdAt,
-      verified: user.isVerified 
+      verified: user.isVerified,
     };
   }
 
@@ -1163,7 +1177,7 @@ export class BusinessService {
     // Check if user is a business owner
     const business = await this.businessRepo.findOne({
       where: { owner: { id: userId } },
-      relations: ['owner']
+      relations: ['owner'],
     });
 
     if (business) {
@@ -1174,9 +1188,8 @@ export class BusinessService {
           BusinessCategory.NAIL_SERVICES,
           BusinessCategory.MAKEUP_SERVICES,
         ];
-        await this.businessRepo.save(business);
       }
-      
+
       return {
         id: business.id,
         businessName: business.businessName,
@@ -1192,7 +1205,7 @@ export class BusinessService {
           firstName: business.owner.firstName,
           surname: business.owner.surname,
           email: business.owner.email,
-          phoneNumber: business.owner.phoneNumber
+          phoneNumber: business.owner.phoneNumber,
         },
       };
     }
@@ -1202,7 +1215,7 @@ export class BusinessService {
     // Check if user is a staff member
     const staff = await this.staffRepo.findOne({
       where: { id: userId },
-      relations: ['business', 'business.owner']
+      relations: ['business', 'business.owner'],
     });
 
     if (staff && staff.business) {
@@ -1213,9 +1226,8 @@ export class BusinessService {
           BusinessCategory.NAIL_SERVICES,
           BusinessCategory.MAKEUP_SERVICES,
         ];
-        await this.businessRepo.save(staff.business);
       }
-      
+
       return {
         id: staff.business.id,
         businessName: staff.business.businessName,
@@ -1231,7 +1243,7 @@ export class BusinessService {
           firstName: staff.business.owner.firstName,
           surname: staff.business.owner.surname,
           email: staff.business.owner.email,
-          phoneNumber: staff.business.owner.phoneNumber
+          phoneNumber: staff.business.owner.phoneNumber,
         },
       };
     }
@@ -1287,7 +1299,7 @@ export class BusinessService {
     // Check if user is a staff member
     const staff = await this.staffRepo.findOne({
       where: { id: userId },
-      relations: ['business']
+      relations: ['business'],
     });
 
     if (staff && staff.business) {
@@ -1303,7 +1315,10 @@ export class BusinessService {
     throw new NotFoundException('No business found for this user');
   }
 
-  async removeBusinessCategories(userId: string, categoriesToRemove: BusinessCategory[]) {
+  async removeBusinessCategories(
+    userId: string,
+    categoriesToRemove: BusinessCategory[],
+  ) {
     // Check if user is a business owner
     const business = await this.businessRepo.findOne({
       where: { owner: { id: userId } },
@@ -1314,12 +1329,13 @@ export class BusinessService {
       if (!business.category) {
         business.category = [];
       }
-      
+
       // Filter out the categories to remove
       business.category = business.category.filter(
-        category => !categoriesToRemove.includes(category as BusinessCategory)
+        (category) =>
+          !categoriesToRemove.includes(category as BusinessCategory),
       );
-      
+
       await this.businessRepo.save(business);
       return {
         message: 'Business categories removed successfully',
@@ -1333,7 +1349,7 @@ export class BusinessService {
     // Check if user is a staff member
     const staff = await this.staffRepo.findOne({
       where: { id: userId },
-      relations: ['business']
+      relations: ['business'],
     });
 
     if (staff && staff.business) {
@@ -1341,12 +1357,13 @@ export class BusinessService {
       if (!staff.business.category) {
         staff.business.category = [];
       }
-      
+
       // Filter out the categories to remove
       staff.business.category = staff.business.category.filter(
-        category => !categoriesToRemove.includes(category as BusinessCategory)
+        (category) =>
+          !categoriesToRemove.includes(category as BusinessCategory),
       );
-      
+
       await this.businessRepo.save(staff.business);
       return {
         message: 'Business categories removed successfully',


### PR DESCRIPTION
## Summary
Fixes deleted service categories respawning after a page refresh.

## Root cause
getBusinessDetails (a read/GET-style endpoint) was writing default 
categories back to the database whenever it saw an empty category array - 
meaning simply viewing the business details page after deleting all 
categories silently undid the deletion.

## Fix
Removed the two businessRepo.save() calls inside getBusinessDetails - 
defaults are still returned in the response when needed, but no longer 
persisted to the database on a read.

## Testing
Verified: deleted an empty category (no attached services, which the 
backend correctly blocks deletion for otherwise), refreshed the page fully, 
confirmed the category stayed deleted instead of respawning.

## Scope
i did not touch removeBusinessCategories (already working correctly) or the 
existing safety checks preventing deletion of categories with services or 
services with appointments.