### PR TITLE
fix to get through to 287 -ADJ - widen email_verifications/phone_verifications otp columns to var 18/07/2026

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "drop-index": "ts-node --project tsconfig.json ./scripts/drop-index.ts",
     "add:addr-cascade": "ts-node --project tsconfig.json ./scripts/add-user-address-cascade.ts",
     "fix:user-fks": "ts-node --project tsconfig.json ./scripts/fix-all-user-fk-cascades.ts",
+    "fix:otp-column-length": "ts-node --project tsconfig.json ./scripts/fix-otp-column-length.ts",
     "delete-business": "ts-node --project tsconfig.json ./scripts/delete-business.ts",
     "cleanup-tx": "ts-node --project tsconfig.json ./scripts/cleanup-transaction.ts",
     "seed:appointments": "ts-node --project tsconfig.json ./scripts/seed-appointment-management.ts",

--- a/scripts/fix-otp-column-length.ts
+++ b/scripts/fix-otp-column-length.ts
@@ -1,0 +1,49 @@
+import { Client } from 'pg';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+// email_verifications.otp and phone_verifications.otp were left at
+// varchar(6) from before OTPs were hashed. OtpService.hashOtp() stores a
+// SHA-256 hex digest (64 chars), which the entities already declare
+// (@Column({ length: 64 })), but the live schema was never updated to
+// match -- every OTP request fails with "value too long for type
+// character varying(6)". This widens both columns to match the entities.
+
+const run = async () => {
+  const client = new Client({
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT),
+    user: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_DATABASE,
+  });
+
+  await client.connect();
+  console.log('Connected.');
+
+  try {
+    await client.query(
+      'ALTER TABLE email_verifications ALTER COLUMN otp TYPE character varying(64)',
+    );
+    await client.query(
+      'ALTER TABLE phone_verifications ALTER COLUMN otp TYPE character varying(64)',
+    );
+
+    const res = await client.query(
+      `SELECT table_name, column_name, character_maximum_length
+       FROM information_schema.columns
+       WHERE table_name IN ('email_verifications', 'phone_verifications')
+         AND column_name = 'otp'`,
+    );
+    console.table(res.rows);
+    console.log('✅ otp columns widened to varchar(64).');
+  } finally {
+    await client.end();
+  }
+};
+
+run().catch((error) => {
+  console.error('Failed to fix otp column length:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Summary
email_verifications.otp and phone_verifications.otp were left at varchar(6) from before OTP codes were hashed. OtpService.hashOtp() stores a SHA-256 hex digest (64 chars) — the entities already declare length: 64, but the live schema was never migrated to match, so every OTP request (business signup, password reset) fails with value too long for type character varying(6).

Checked the tracking register — not an existing ticket. Likely a side effect of whoever added hashing (updating the entity but not the live DB).

Changes

scripts/fix-otp-column-length.ts — widens both columns to varchar(64) (idempotent, safe to re-run).
package.json — adds npm run fix:otp-column-length.
Note: This only fixes whatever database you run it against. If staging/prod have the same drift, run this same script there too.

Test plan

Ran the script, confirmed both columns now varchar(64).
Hit POST /api/auth/business/otp/request directly — confirmed 200 OK, OTP sent successfully (previously 500).
