### PR TITLE
Rem 446 447 448-ADJ-add service 500 error- 2026 /7/19

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "drop-index": "ts-node --project tsconfig.json ./scripts/drop-index.ts",
+    "fix:service-price-column": "ts-node --project tsconfig.json ./scripts/fix-service-price-column-type.ts",
     "add:addr-cascade": "ts-node --project tsconfig.json ./scripts/add-user-address-cascade.ts",
     "fix:user-fks": "ts-node --project tsconfig.json ./scripts/fix-all-user-fk-cascades.ts",
     "delete-business": "ts-node --project tsconfig.json ./scripts/delete-business.ts",

--- a/scripts/fix-service-price-column-type.ts
+++ b/scripts/fix-service-price-column-type.ts
@@ -1,0 +1,45 @@
+import { Client } from 'pg';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+// The "Service" table's price column was left as integer, but the entity
+// declares it decimal(10,2) (matching minPrice/maxPrice, which are already
+// numeric). Any non-whole-number price (e.g. 45.99) throws an uncaught
+// Postgres error (22P02, pg_strtoint32_safe) trying to insert a decimal
+// string into an integer column, surfacing as a raw 500 to the user. This
+// widens the column to match the entity.
+
+const run = async () => {
+  const client = new Client({
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT),
+    user: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_DATABASE,
+  });
+
+  await client.connect();
+  console.log('Connected.');
+
+  try {
+    await client.query(
+      'ALTER TABLE "Service" ALTER COLUMN price TYPE numeric(10,2)',
+    );
+
+    const res = await client.query(
+      `SELECT column_name, data_type, numeric_precision, numeric_scale
+       FROM information_schema.columns
+       WHERE table_name = 'Service' AND column_name IN ('price', 'minPrice', 'maxPrice')`,
+    );
+    console.table(res.rows);
+    console.log('✅ Service.price widened to numeric(10,2).');
+  } finally {
+    await client.end();
+  }
+};
+
+run().catch((error) => {
+  console.error('Failed to fix Service.price column type:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Summary
Service.price was integer in the live database while the entity declares decimal(10,2) (matching minPrice/maxPrice, already correctly numeric). Any price with cents (e.g. 45.99) threw an uncaught Postgres error (22P02, pg_strtoint32_safe), surfacing as a raw 500.

Correction to the original report: REM-446 attributed the crash to "team member assigned," but live testing isolated the real trigger — a whole-number price with staff assigned saves fine (201); a decimal price fails with or without staff assigned. Staff assignment was incidental to how the original tester happened to enter the price.

Changes

scripts/fix-service-price-column-type.ts — widens the column to numeric(10,2).