### PR TITLE
Rem 367 - ADJ - optional fields 2026 07 19

### DIFF
--- a/src/business/dtos/requests/CreateBlockedTimeDto.ts
+++ b/src/business/dtos/requests/CreateBlockedTimeDto.ts
@@ -1,13 +1,14 @@
 import {
     IsNotEmpty,
+    IsOptional,
 } from 'class-validator';
 
 
 export class CreateBlockedTimeDto {
-    @IsNotEmpty()
+    @IsOptional()
     type: string;
 
-    @IsNotEmpty()
+    @IsOptional()
     title: string;
 
     @IsNotEmpty({ message: 'date must not be empty.' })
@@ -19,10 +20,10 @@ export class CreateBlockedTimeDto {
     @IsNotEmpty()
     endTime: string;
 
-    @IsNotEmpty()
+    @IsOptional()
     teamMember: string;
 
-    @IsNotEmpty()
+    @IsOptional()
     description: string;
 
     ownerMail?: string;


### PR DESCRIPTION
## Summary
- CreateBlockedTimeDto forced type, title, teamMember, and description to be @IsNotEmpty(), but the blocked_time_slots entity marks all four nullable: true — the mismatch rejected requests that left those fields blank.
- Changed those 4 fields to @IsOptional(). date, startTime, endTime remain required. Same DTO backs both create and edit endpoints.

