### PR TITLE
Rem 498 -ADJ- giftcard merchant scoping 30/07/2026

### DIFF
--- a/src/business/controllers/business-giftcard.controller.ts
+++ b/src/business/controllers/business-giftcard.controller.ts
@@ -132,7 +132,7 @@ export class BusinessGiftCardsController {
           HttpStatus.UNAUTHORIZED,
         );
       }
-      const result = await this.giftCardsService.getBusinessSummary();
+      const result = await this.giftCardsService.getBusinessSummary(ownerId);
 
       return {
         success: true,
@@ -168,7 +168,7 @@ export class BusinessGiftCardsController {
         );
       }
 
-      const result = await this.giftCardsService.getGiftCardsList(filters);
+      const result = await this.giftCardsService.getGiftCardsList(filters, ownerId);
 
       return {
         success: true,

--- a/src/business/services/business-giftcard.service.ts
+++ b/src/business/services/business-giftcard.service.ts
@@ -73,11 +73,22 @@ export class BusinessGiftCardsService {
     return await this.giftCardRepository.save(giftCard);
   }
 
-  async getBusinessSummary(): Promise<any> {
-    // Fetch all cards EXCEPT deleted
+  async getBusinessSummary(ownerId: string): Promise<any> {
+    const business = await this.businessRepository.findOne({
+      where: { ownerId },
+    });
+
+    if (!business) {
+      throw new BadRequestException(`No business found for this user`);
+    }
+
+    // Fetch all cards for this business EXCEPT deleted
     const allCards = await this.giftCardRepository
       .createQueryBuilder('giftCard')
       .where('giftCard.status != :deleted', { deleted: 'deleted' })
+      .andWhere('giftCard.businessId = :businessId', {
+        businessId: business.id,
+      })
       .getMany();
 
     const now = new Date();
@@ -147,7 +158,15 @@ export class BusinessGiftCardsService {
   /**
    * Get gift card list with filtering and pagination
    */
-  async getGiftCardsList(filters: BusinessGiftCardFiltersDto) {
+  async getGiftCardsList(filters: BusinessGiftCardFiltersDto, ownerId: string) {
+    const business = await this.businessRepository.findOne({
+      where: { ownerId },
+    });
+
+    if (!business) {
+      throw new BadRequestException(`No business found for this user`);
+    }
+
     const {
       search,
       sortBy = 'createdAt',
@@ -163,6 +182,11 @@ export class BusinessGiftCardsService {
     /* --------- ALWAYS exclude deleted ---------- */
     queryBuilder.andWhere('giftCard.status != :deletedStatus', {
       deletedStatus: 'deleted',
+    });
+
+    /* --------- SCOPE TO THIS MERCHANT'S BUSINESS ---------- */
+    queryBuilder.andWhere('giftCard.businessId = :businessId', {
+      businessId: business.id,
     });
 
     /* --------- RELATIONS ---------- */


### PR DESCRIPTION
## Summary (backend)
- `getBusinessGiftCardSummary` and `getBusinessGiftCardsList` both extracted `ownerId` from the JWT but never passed it into the service layer — the summary aggregated every merchant's gift cards, and the list had no business filter at all.
- Added a business lookup by `ownerId` and scoped both queries to `businessId`.

## Test plan
- [ ] `npm run seed:rem-498` (from the QA seeds branch) to seed one card for the test merchant + one for a different merchant
- [ ] Log in as the test merchant, Gift Cards page shows exactly 1 card, correct total value — not the other merchant's card