### PR TITLE
Feat/merchant support chat 2026 07 30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@paypal/checkout-server-sdk": "^1.0.3",
         "@prisma/client": "^6.17.1",
         "@sendgrid/mail": "^8.1.6",
+        "@slack/web-api": "^8.0.0",
         "@types/streamifier": "^0.1.2",
         "argon2": "^0.44.0",
         "axios": "^1.13.2",
@@ -270,7 +271,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -810,13 +810,39 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2235,7 +2261,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2382,7 +2407,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.18.tgz",
       "integrity": "sha512-0sLq8Z+TIjLnz1Tqp0C/x9BpLbqpt1qEu0VcH4/fkE0y3F5JxhfK1AdKQ/SPbKhKgwqVDoY4gS8GQr2G6ujaWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.4",
         "iterare": "1.2.1",
@@ -2442,7 +2466,6 @@
       "integrity": "sha512-wR3DtGyk/LUAiPtbXDuWJJwVkWElKBY0sqnTzf9d4uM3+X18FRZhK7WFc47czsIGOdWuRsMeLYV+1Z9dO4zDEQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2551,7 +2574,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.28.tgz",
       "integrity": "sha512-hU+9Sz4m+onHrR5AmelI59QKmY/Re546bPnygnpqqeQdHDiJpBgjWbL4t6Jr73CBpS60cpyng7WzjgphNB9iwA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -2573,7 +2595,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.27.tgz",
       "integrity": "sha512-xgpLzaIDGOCC6xOAtHnRAz8sqieFgGxxu3MN5ID026Jt6oeL3efp29N5QHhPr7UlqBfy/Jd02uj0POkZq6Au3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "socket.io": "4.8.3",
         "tslib": "2.8.1"
@@ -2776,7 +2797,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.27.tgz",
       "integrity": "sha512-X3OgJt9KgYTvt9D7sNz9SOj3A1daAHy7DZrYhM1pky8Fh+erlKQH5IQ/tKm+GaJKA5M0srBUr1CMqjak/qNxOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -3047,6 +3067,49 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@slack/logger": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-5.0.0.tgz",
+      "integrity": "sha512-VGXhmmgsAo9shdQYh4tFDndd+7nsgp0Y5h0UPDaUp8K359pBasI6YdkMqFW3mCOxLQkq09qj7o7cq6f3DuXcJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20"
+      },
+      "engines": {
+        "node": ">= 20",
+        "npm": ">=9.6.4"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-KNOqpnNAlsFt5Jk9XBclslQ0lobRIg/0tnhpmvZJAglHJx9E8oceN8hC3gaBzkR6UzQ9Wzq4rLsJ98wUcxWPfw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20",
+        "npm": ">=9.6.4"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-8.0.0.tgz",
+      "integrity": "sha512-ORx3XQryQPq2Jnxv5giSKXVoQRUeylrrymIR2S9fPzLjPcCts8RayMeBSZMcpfpAqp6fnBRuPW2UB6dUPUTEZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^5.0.0",
+        "@slack/types": "^3.0.0",
+        "@types/node": ">=20",
+        "@types/retry": "0.12.0",
+        "eventemitter3": "^5.0.1",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 20",
+        "npm": ">=9.6.4"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -3372,7 +3435,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
       "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3421,6 +3483,12 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
     "node_modules/@types/send": {
@@ -3586,7 +3654,6 @@
       "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.1",
         "@typescript-eslint/types": "8.62.1",
@@ -4372,7 +4439,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4434,7 +4500,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4952,7 +5017,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -5279,15 +5343,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.4",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
       "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -6174,7 +6236,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6235,7 +6296,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6400,6 +6460,12 @@
       "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
       "license": "MIT"
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -6474,7 +6540,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7873,7 +7938,6 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
       "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.10.0",
         "cluster-key-slot": "1.1.1",
@@ -8169,7 +8233,6 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -9490,6 +9553,7 @@
       "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
@@ -9569,6 +9633,7 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -9587,6 +9652,7 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -9600,6 +9666,7 @@
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -9614,7 +9681,8 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/minimizer-webpack-plugin/node_modules/schema-utils": {
       "version": "4.3.3",
@@ -9622,6 +9690,7 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -9642,6 +9711,7 @@
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -9710,7 +9780,6 @@
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.1.tgz",
       "integrity": "sha512-UpHBA0l5kHyKJQFjmBaFYQFo5sgz1DK0TRqDkOyBLYbqiIbKKhIvBpHWBXqeo0rgW4kGI1UhhAw+kTQZoj1BdA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bson": "^6.10.4",
         "kareem": "2.6.3",
@@ -9726,22 +9795,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
-      }
-    },
-    "node_modules/mongoose/node_modules/gaxios": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {
@@ -10263,6 +10316,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -10293,6 +10355,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -10357,7 +10466,6 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -10502,7 +10610,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -10771,7 +10878,6 @@
       "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10830,7 +10936,6 @@
       "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -11044,8 +11149,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -11119,6 +11223,15 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/rimraf": {
       "version": "5.0.10",
@@ -11223,7 +11336,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -12185,7 +12297,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12533,7 +12644,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12729,7 +12839,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.31.tgz",
       "integrity": "sha512-6u9EFtdLBgHjnPm78NStVeM+I/1MolTzKykDDcydzKUkh6E++YS6XViU/fePJbvDvEGU4Xq34KOM/CLeer9I2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.3.1",
@@ -12945,7 +13054,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13366,6 +13474,7 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -13384,6 +13493,7 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -13397,6 +13507,7 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -13411,6 +13522,7 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -13420,7 +13532,8 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webpack/node_modules/schema-utils": {
       "version": "4.3.3",
@@ -13428,6 +13541,7 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@paypal/checkout-server-sdk": "^1.0.3",
     "@prisma/client": "^6.17.1",
     "@sendgrid/mail": "^8.1.6",
+    "@slack/web-api": "^8.0.0",
     "@types/streamifier": "^0.1.2",
     "argon2": "^0.44.0",
     "axios": "^1.13.2",

--- a/scripts/add-tickets-table.ts
+++ b/scripts/add-tickets-table.ts
@@ -1,0 +1,74 @@
+/**
+ * ONE-OFF MIGRATION SCRIPT — creates the tickets table and adds ticketId
+ * to chat_messages, for the support-chat ticketing feature.
+ *
+ * TypeORM's synchronize() is never actually invoked at boot in this repo
+ * (app.module.ts wires TypeOrmModule.forRoot directly, bypassing the
+ * SYNC_ONLY_TABLES mechanism documented in src/config/database.ts), so new
+ * tables/columns need a manual script like this one.
+ *
+ * Run with:
+ *   npx ts-node scripts/add-tickets-table.ts
+ */
+import { Client } from 'pg';
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+async function run() {
+  const client = new Client({
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT),
+    user: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_DATABASE,
+  });
+  await client.connect();
+  console.log('Connected to database.');
+
+  await client.query(`
+    DO $$ BEGIN
+      CREATE TYPE tickets_status_enum AS ENUM ('open', 'closed');
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+    END $$;
+  `);
+  console.log('tickets_status_enum type ensured.');
+
+  // customerId/assignedAdminId/closedById must be uuid, matching User.id's
+  // column type (@PrimaryGeneratedColumn('uuid')) — Postgres has no
+  // implicit uuid = varchar comparison, so TypeORM's relation queries
+  // (e.g. WHERE customer.id = :id) fail at runtime with a varchar column.
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS tickets (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      "ticketNumber" varchar UNIQUE NOT NULL,
+      "customerId" uuid NOT NULL,
+      "assignedAdminId" uuid NULL,
+      status tickets_status_enum NOT NULL DEFAULT 'open',
+      "closedById" uuid NULL,
+      "closedAt" timestamp NULL,
+      "createdAt" timestamp NOT NULL DEFAULT now(),
+      "updatedAt" timestamp NOT NULL DEFAULT now()
+    );
+  `);
+  console.log('tickets table ensured.');
+
+  await client.query(`
+    ALTER TABLE chat_messages
+    ADD COLUMN IF NOT EXISTS "ticketId" uuid NULL;
+  `);
+  console.log('ticketId column added to chat_messages (or already existed).');
+
+  await client.query(`
+    CREATE SEQUENCE IF NOT EXISTS ticket_number_seq START 1001;
+  `);
+  console.log('ticket_number_seq sequence ensured.');
+
+  await client.end();
+  console.log('Done.');
+}
+
+run().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/scripts/seed-test-customer.ts
+++ b/scripts/seed-test-customer.ts
@@ -1,0 +1,86 @@
+/**
+ * ONE-OFF LOCAL DEV SCRIPT — creates a verified customer user directly in
+ * the DB, for testing the customer-side chat flow against the seeded
+ * admin from seed-admin.ts.
+ *
+ * NOT for staging/production use — local testing only.
+ *
+ * Run with:
+ *   npx ts-node scripts/seed-test-customer.ts
+ */
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import * as dotenv from 'dotenv';
+import * as bcrypt from 'bcrypt';
+
+dotenv.config();
+
+const EMAIL = 'test-customer@khs.local';
+const PASSWORD = 'TestPassword123!';
+
+const AppDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DB_HOST ?? 'localhost',
+  port: parseInt(process.env.DB_PORT ?? '5432', 10),
+  username: process.env.DB_USERNAME ?? 'postgres',
+  password: process.env.DB_PASSWORD ?? 'password',
+  database: process.env.DB_DATABASE ?? 'khs',
+  ssl:
+    process.env.NODE_ENV === 'production'
+      ? { rejectUnauthorized: false }
+      : false,
+});
+
+async function seedTestCustomer() {
+  await AppDataSource.initialize();
+  console.log('Database connected');
+
+  const existing = await AppDataSource.query(
+    `SELECT id FROM "user" WHERE email = $1`,
+    [EMAIL],
+  );
+
+  if (existing.length > 0) {
+    console.log(`Customer already exists: ${EMAIL} (id: ${existing[0].id})`);
+    console.log(`Login with password: ${PASSWORD}`);
+    await AppDataSource.destroy();
+    return;
+  }
+
+  const hash = await bcrypt.hash(PASSWORD, await bcrypt.genSalt(10));
+
+  const result = await AppDataSource.query(
+    `INSERT INTO "user" (
+      email, password, "firstName", surname,
+      "isVerified", "isSuperAdmin", "isAdmin",
+      "isBusiness", "isClient", "isCustomer", "isManager", "isBusinessAdmin", "isStaff",
+      "createdAt", "updatedAt"
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW(), NOW())
+    RETURNING id`,
+    [
+      EMAIL,
+      hash,
+      'Test',
+      'Customer',
+      true, // isVerified
+      false, // isSuperAdmin
+      false, // isAdmin
+      false, // isBusiness
+      true, // isClient
+      true, // isCustomer
+      false, // isManager
+      false, // isBusinessAdmin
+      false, // isStaff
+    ],
+  );
+
+  console.log(`Created test customer: ${EMAIL} (id: ${result[0].id})`);
+  console.log(`Login with password: ${PASSWORD}`);
+
+  await AppDataSource.destroy();
+}
+
+seedTestCustomer().catch((error) => {
+  console.error('Failed to seed test customer:', error.message);
+  process.exit(1);
+});

--- a/scripts/seed-test-merchant.ts
+++ b/scripts/seed-test-merchant.ts
@@ -1,0 +1,119 @@
+/**
+ * ONE-OFF LOCAL DEV SCRIPT — creates a verified, approved merchant user
+ * (plus its Business row) directly in the DB, for testing the merchant
+ * dashboard/support-chat flow.
+ *
+ * Business.status is set to 'approved' directly — otherwise the merchant
+ * dashboard would be stuck behind the under-review flow with nothing to
+ * test against.
+ *
+ * NOT for staging/production use — local testing only.
+ *
+ * Run with:
+ *   npx ts-node scripts/seed-test-merchant.ts
+ */
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import * as dotenv from 'dotenv';
+import * as bcrypt from 'bcrypt';
+
+dotenv.config();
+
+const EMAIL = 'test-merchant@khs.local';
+const PASSWORD = 'TestPassword123!';
+
+const AppDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DB_HOST ?? 'localhost',
+  port: parseInt(process.env.DB_PORT ?? '5432', 10),
+  username: process.env.DB_USERNAME ?? 'postgres',
+  password: process.env.DB_PASSWORD ?? 'password',
+  database: process.env.DB_DATABASE ?? 'khs',
+  ssl:
+    process.env.NODE_ENV === 'production'
+      ? { rejectUnauthorized: false }
+      : false,
+});
+
+async function seedTestMerchant() {
+  await AppDataSource.initialize();
+  console.log('Database connected');
+
+  const existingUser = await AppDataSource.query(
+    `SELECT id FROM "user" WHERE email = $1`,
+    [EMAIL],
+  );
+
+  let userId: string;
+
+  if (existingUser.length > 0) {
+    userId = existingUser[0].id;
+    console.log(`Merchant user already exists: ${EMAIL} (id: ${userId})`);
+  } else {
+    const hash = await bcrypt.hash(PASSWORD, await bcrypt.genSalt(10));
+
+    const result = await AppDataSource.query(
+      `INSERT INTO "user" (
+        email, password, "firstName", surname,
+        "isVerified", "isSuperAdmin", "isAdmin",
+        "isBusiness", "isMerchant", "isClient", "isManager", "isBusinessAdmin", "isStaff",
+        "createdAt", "updatedAt"
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW(), NOW())
+      RETURNING id`,
+      [
+        EMAIL,
+        hash,
+        'Test',
+        'Merchant',
+        true, // isVerified
+        false, // isSuperAdmin
+        false, // isAdmin
+        true, // isBusiness
+        true, // isMerchant
+        false, // isClient
+        false, // isManager
+        false, // isBusinessAdmin
+        false, // isStaff
+      ],
+    );
+    userId = result[0].id;
+    console.log(`Created merchant user: ${EMAIL} (id: ${userId})`);
+  }
+
+  const existingBusiness = await AppDataSource.query(
+    `SELECT id FROM businesses WHERE owner_id = $1`,
+    [userId],
+  );
+
+  if (existingBusiness.length > 0) {
+    console.log(`Business already exists (id: ${existingBusiness[0].id})`);
+  } else {
+    const business = await AppDataSource.query(
+      `INSERT INTO businesses (
+        "businessName", description, owner_id, "ownerName", "ownerEmail",
+        "primaryAudience", "companySize", status
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      RETURNING id`,
+      [
+        'Test Merchant Salon',
+        'Seeded test business for merchant-side dev/testing.',
+        userId,
+        'Test Merchant',
+        EMAIL,
+        'Everyone',
+        'solo',
+        'approved',
+      ],
+    );
+    console.log(`Created business: Test Merchant Salon (id: ${business[0].id})`);
+  }
+
+  console.log(`Login with password: ${PASSWORD}`);
+
+  await AppDataSource.destroy();
+}
+
+seedTestMerchant().catch((error) => {
+  console.error('Failed to seed test merchant:', error.message);
+  process.exit(1);
+});

--- a/src/admin/live-chat/chat.controller.ts
+++ b/src/admin/live-chat/chat.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Get, Query, UseGuards, Param } from '@nestjs/common';
+import { Controller, Post, Patch, Body, Get, Query, UseGuards, Param, BadRequestException } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
 import { JwtAuthGuard } from 'src/middleware/jwt-auth.guard';
@@ -9,7 +9,8 @@ import { ChatGateway } from './chat.gateway';
 import { CloudinaryService } from 'src/helpers/cloudinary-massage-image-helper';
 import { User } from 'src/all_user_entities/user.entity';
 import { RolesGuard } from 'src/middleware/roles.guard';
-import { ChatMessageResponseDto, SendMessageDto } from './send-message.dto';
+import { Ticket, TicketStatus } from 'src/all_user_entities/ticket.entity';
+import { ChatMessageResponseDto, SendMessageDto, StaffContactDto } from './send-message.dto';
 import { GetUser } from 'src/middleware/get-user.decorator';
 
 @ApiTags('Admin and Client Chat')
@@ -29,6 +30,26 @@ export class ChatController {
     @GetUser() user: User,
     @Body() data: SendMessageDto,
   ) {
+    // The ticket always belongs to the customer side of the exchange,
+    // regardless of who's actually sending this particular message.
+    const customerId = user.isStaff ? data.receiverId : user.id;
+
+    // Staff replying always targets a specific ticket (the one they have
+    // open in their inbox) — a customer with only one open ticket can
+    // omit it and let the service resolve/create it automatically.
+    let ticket = data.ticketId
+      ? await this.chatService.getTicketById(data.ticketId)
+      : await this.chatService.getSingleOpenTicketOrCreate(customerId);
+
+    if (!ticket) {
+      throw new BadRequestException('Ticket not found');
+    }
+    if (ticket.status === TicketStatus.CLOSED) {
+      throw new BadRequestException(
+        'This ticket is closed. Start a new conversation instead.',
+      );
+    }
+
     let imageUrl: string | undefined;
 
     if (data.imageBase64) {
@@ -36,15 +57,37 @@ export class ChatController {
     }
 
     const saved = await this.chatService.storeMessage({
+      ticket: { id: ticket.id } as Ticket,
       sender: user,
       receiver: { id: data.receiverId } as User,
       message: data.message,
       imageUrl,
     });
 
-    await this.chatGateway.sendMessageToReceiver(saved);
+    // The gateway broadcast and this endpoint's response both need to
+    // carry sender/receiver info (id, name, avatar, email — used by the
+    // frontend's real-time handlers), but never the raw User entity,
+    // which includes the bcrypt password hash.
+    const safeMessage = {
+      id: saved.id,
+      ticket: { id: ticket.id },
+      message: saved.message,
+      imageUrl: saved.imageUrl,
+      read: saved.read,
+      createdAt: saved.createdAt,
+      sender: {
+        id: user.id,
+        firstName: user.firstName,
+        surname: user.surname,
+        email: user.email,
+        avatarUrl: user.avatarUrl,
+      },
+      receiver: { id: data.receiverId },
+    };
 
-    return saved;
+    await this.chatGateway.sendMessageToReceiver(safeMessage);
+
+    return safeMessage;
   }
 
   @Get('messages')
@@ -60,6 +103,23 @@ export class ChatController {
     return this.chatService.getChatList(user.id);
   }
 
+  // Staff a customer can start a new conversation with, even if no
+  // messages have been exchanged yet (getChatList only shows existing
+  // conversations).
+  @Get('admins')
+  async getAllStaffContacts(): Promise<StaffContactDto[]> {
+    return this.chatService.getAllStaffContacts();
+  }
+
+  @Patch('read/:otherUserId')
+  async markConversationAsRead(
+    @GetUser() user: User,
+    @Param('otherUserId') otherUserId: string,
+  ) {
+    await this.chatService.markConversationAsRead(user.id, otherUserId);
+    return { success: true };
+  }
+
   // GET /chat/messages/:otherUserId
   @Get('messages/:otherUserId')
   async getMessagesBetweenUsers(
@@ -67,5 +127,68 @@ export class ChatController {
     @Param('otherUserId') otherUserId: string  // Second user passed via URL
   ): Promise<ChatMessageResponseDto[]> {
     return this.chatService.getChatMessageWithUserInfo(user.id, otherUserId);
+  }
+
+  // ─── Tickets ────────────────────────────────────────────────────────────
+
+  // All of this customer's currently-open tickets — up to the 2-ticket cap.
+  // The widget shows these to resume; "start a new conversation" is only
+  // offered/allowed when this list has room under the cap.
+  @Get('tickets/mine')
+  async getMyOpenTickets(@GetUser() user: User) {
+    return this.chatService.getMyOpenTickets(user.id);
+  }
+
+  // Explicit creation, separate from sendMessage's auto-resolve — this is
+  // what "start a new conversation" calls, and it's where the open-ticket
+  // cap is actually enforced (also re-checked defensively in sendMessage's
+  // auto-resolve path for the 0/1-ticket case). assignedAdminId is the
+  // staff member the customer picked from "Talk to our team".
+  @Post('tickets')
+  async createTicket(
+    @GetUser() user: User,
+    @Body('assignedAdminId') assignedAdminId?: string,
+  ) {
+    return this.chatService.createTicket(user.id, assignedAdminId);
+  }
+
+  // Every ticket this customer has ever opened, not just the current one —
+  // backs a "past conversations" view on the customer widget.
+  @Get('tickets/mine/history')
+  async getMyTicketHistory(@GetUser() user: User) {
+    return this.chatService.listMyTickets(user.id);
+  }
+
+  @Get('tickets')
+  async listTickets(@Query('status') status: TicketStatus = TicketStatus.OPEN) {
+    return this.chatService.listTickets(status);
+  }
+
+  @Get('tickets/search')
+  async searchTicketByNumber(@Query('number') number: string) {
+    const ticket = await this.chatService.getTicketByNumber(number);
+    if (!ticket) {
+      throw new BadRequestException(`No ticket found with number ${number}`);
+    }
+    return ticket;
+  }
+
+  // Ticket-scoped message history — the real boundary a closed ticket
+  // needs, so reopening a conversation never blends old and new tickets.
+  @Get('tickets/:id/messages')
+  async getMessagesByTicket(@Param('id') id: string): Promise<ChatMessageResponseDto[]> {
+    return this.chatService.getMessagesByTicket(id);
+  }
+
+  // Any staff member viewing a ticket can close it — no assignment/
+  // ownership restriction.
+  @Patch('tickets/:id/close')
+  async closeTicket(
+    @GetUser() user: User,
+    @Param('id') id: string,
+  ) {
+    const ticket = await this.chatService.closeTicket(id, user.id);
+    this.chatGateway.notifyTicketClosed(ticket);
+    return ticket;
   }
 }

--- a/src/admin/live-chat/chat.gateway.ts
+++ b/src/admin/live-chat/chat.gateway.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { ChatService } from './chat.service';
+import { TicketResponseDto } from './send-message.dto';
 
 @WebSocketGateway({ cors: true })
 export class ChatGateway {
@@ -18,14 +19,20 @@ export class ChatGateway {
   constructor(private readonly chatService: ChatService) {}
 
   @SubscribeMessage('join')
-  async handleJoin(@ConnectedSocket() client: Socket, userId: string) {
+  async handleJoin(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() userId: string,
+  ) {
     this.onlineUsers.set(userId, client.id);
     await this.chatService.setUserOnline(userId, true);
     this.server.emit('user_status', { userId, isOnline: true });
   }
 
   @SubscribeMessage('leave')
-  async handleLeave(@ConnectedSocket() client: Socket, userId: string) {
+  async handleLeave(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() userId: string,
+  ) {
     this.onlineUsers.delete(userId);
     await this.chatService.setUserOnline(userId, false);
     this.server.emit('user_status', { userId, isOnline: false });
@@ -36,5 +43,12 @@ export class ChatGateway {
     if (receiverSocketId) {
       this.server.to(receiverSocketId).emit('receive_message', message);
     }
+  }
+
+  // Broadcast so both the customer (whose input should now disable) and
+  // any admin with this ticket open (whose tab should move to Closed) pick
+  // it up live — mirrors how user_status is already broadcast to everyone.
+  notifyTicketClosed(ticket: TicketResponseDto) {
+    this.server.emit('ticket_closed', ticket);
   }
 }

--- a/src/admin/live-chat/chat.gateway.ts
+++ b/src/admin/live-chat/chat.gateway.ts
@@ -5,6 +5,7 @@ import {
   ConnectedSocket,
   MessageBody,
 } from '@nestjs/websockets';
+import { Inject, forwardRef } from '@nestjs/common';
 import { Server, Socket } from 'socket.io';
 import { ChatService } from './chat.service';
 import { TicketResponseDto } from './send-message.dto';
@@ -16,7 +17,10 @@ export class ChatGateway {
 
   private onlineUsers = new Map<string, string>();
 
-  constructor(private readonly chatService: ChatService) {}
+  constructor(
+    @Inject(forwardRef(() => ChatService))
+    private readonly chatService: ChatService,
+  ) {}
 
   @SubscribeMessage('join')
   async handleJoin(
@@ -50,5 +54,13 @@ export class ChatGateway {
   // it up live — mirrors how user_status is already broadcast to everyone.
   notifyTicketClosed(ticket: TicketResponseDto) {
     this.server.emit('ticket_closed', ticket);
+  }
+
+  // Broadcast so the Team Inbox can prepend a brand-new ticket live —
+  // receive_message alone can't do this, since it only updates a ticket
+  // already present in an admin's list (a new ticket has no existing row
+  // to update), which was why new tickets required a hard refresh to see.
+  notifyTicketCreated(ticket: TicketResponseDto) {
+    this.server.emit('ticket_created', ticket);
   }
 }

--- a/src/admin/live-chat/chat.module.ts
+++ b/src/admin/live-chat/chat.module.ts
@@ -11,9 +11,13 @@ import { CloudinaryService } from 'src/helpers/cloudinary-massage-image-helper';
 import { ChatController } from './chat.controller';
 import { Appointment } from 'src/business/entities/appointment.entity';
 import { Business } from 'src/business/entities/business.entity';
+import { SlackModule } from 'src/slack/slack.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ChatMessage, UserStatus, Appointment, Business, User, Ticket])],
+  imports: [
+    TypeOrmModule.forFeature([ChatMessage, UserStatus, Appointment, Business, User, Ticket]),
+    SlackModule,
+  ],
   providers: [ChatService, ChatGateway, CloudinaryService],
   controllers: [ChatController],
 })

--- a/src/admin/live-chat/chat.module.ts
+++ b/src/admin/live-chat/chat.module.ts
@@ -3,6 +3,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { UserStatus } from 'src/all_user_entities/user-status.entity';
 import { ChatMessage } from 'src/all_user_entities/chat-message.entity';
+import { User } from 'src/all_user_entities/user.entity';
+import { Ticket } from 'src/all_user_entities/ticket.entity';
 import { ChatGateway } from './chat.gateway';
 import { ChatService } from './chat.service';
 import { CloudinaryService } from 'src/helpers/cloudinary-massage-image-helper';
@@ -11,7 +13,7 @@ import { Appointment } from 'src/business/entities/appointment.entity';
 import { Business } from 'src/business/entities/business.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ChatMessage, UserStatus, Appointment, Business])],
+  imports: [TypeOrmModule.forFeature([ChatMessage, UserStatus, Appointment, Business, User, Ticket])],
   providers: [ChatService, ChatGateway, CloudinaryService],
   controllers: [ChatController],
 })

--- a/src/admin/live-chat/chat.service.ts
+++ b/src/admin/live-chat/chat.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
+import { Injectable, BadRequestException, Inject, forwardRef } from '@nestjs/common';
 import { ILike, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 
@@ -9,6 +9,8 @@ import { Ticket, TicketStatus } from 'src/all_user_entities/ticket.entity';
 import { ChatMessageResponseDto, ChatUserInfoDto, StaffContactDto, TicketResponseDto } from './send-message.dto';
 import { Appointment } from 'src/business/entities/appointment.entity';
 import { Business } from 'src/business/entities/business.entity';
+import { ChatGateway } from './chat.gateway';
+import { SlackService } from 'src/slack/slack.service';
 
 const TICKET_NUMBER_SEQUENCE = 'ticket_number_seq';
 
@@ -44,6 +46,11 @@ export class ChatService {
 
     @InjectRepository(Ticket)
     private ticketRepo: Repository<Ticket>,
+
+    @Inject(forwardRef(() => ChatGateway))
+    private readonly chatGateway: ChatGateway,
+
+    private readonly slackService: SlackService,
   ) {}
 
   // Store a new message
@@ -99,7 +106,12 @@ export class ChatService {
       const name =
         `${ticket.customer.firstName ?? ''} ${ticket.customer.surname ?? ''}`.trim() ||
         'Unknown';
-      dto.customer = { name, avatarUrl: ticket.customer.avatarUrl ?? null, isOnline };
+      dto.customer = {
+        name,
+        avatarUrl: ticket.customer.avatarUrl ?? null,
+        isOnline,
+        isMerchant: !!ticket.customer.isMerchant,
+      };
 
       const lastMessage = await this.chatRepo.findOne({
         where: { ticket: { id: ticket.id } },
@@ -153,9 +165,71 @@ export class ChatService {
     });
 
     const saved = await this.ticketRepo.save(ticket);
-    saved.customer = { id: customerId } as User;
-    if (assignedAdminId) saved.assignedAdmin = { id: assignedAdminId } as User;
-    return this.toResponseDto(saved);
+
+    // toResponseDto's withCustomerSummary path reads ticket.customer.firstName
+    // etc. — the bare { id } stub above doesn't have those loaded, so
+    // re-fetch with relations to get the real customer/assignedAdmin rows.
+    const withRelations = await this.ticketRepo.findOne({
+      where: { id: saved.id },
+      relations: ['customer', 'assignedAdmin', 'closedBy'],
+    });
+    const dto = await this.toResponseDto(withRelations!, true);
+
+    // Team Inbox needs to know about brand-new tickets live — receive_message
+    // alone can't add a new row to an admin's list (see chat.gateway.ts).
+    this.chatGateway.notifyTicketCreated(dto);
+
+    const assignedAdminName = withRelations!.assignedAdmin
+      ? `${withRelations!.assignedAdmin.firstName ?? ''} ${withRelations!.assignedAdmin.surname ?? ''}`.trim() || 'Unknown'
+      : null;
+    this.slackService.notify(this.formatTicketCreatedSlackMessage(dto, assignedAdminName));
+
+    return dto;
+  }
+
+  // Matches c2c's standard Slack notification template (header + LOC/
+  // TRIGGER/DETAILS/TIMESTAMP), simplified — KHS doesn't need the
+  // node/provider/severity taxonomy from that codebase, just a clear
+  // ticket-opened alert.
+  private nowInWAT(): string {
+    return new Intl.DateTimeFormat('en-GB', {
+      day: '2-digit', month: '2-digit', year: 'numeric',
+      hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+      timeZone: 'Africa/Lagos',
+    }).format(new Date());
+  }
+
+  private formatTicketCreatedSlackMessage(
+    ticket: TicketResponseDto,
+    assignedAdminName: string | null,
+  ): string {
+    const customerName = ticket.customer?.name ?? 'Unknown';
+    const assignedLine = assignedAdminName
+      ? `• Assigned to: ${assignedAdminName}`
+      : '• Assigned to: _unassigned_';
+
+    return `[KHS] [SUPPORT] [INFO] [TICKET_CREATED]
+*TRIGGER:* \`${customerName}\`
+*DETAILS:*
+New support ticket opened: *${ticket.ticketNumber}*
+• Customer: ${customerName}
+${assignedLine}
+*TIMESTAMP:* \`${this.nowInWAT()} (WAT)\``;
+  }
+
+  private formatTicketClosedSlackMessage(
+    ticket: TicketResponseDto,
+    closedByName: string,
+  ): string {
+    const customerName = ticket.customer?.name ?? 'Unknown';
+
+    return `[KHS] [SUPPORT] [INFO] [TICKET_CLOSED]
+*TRIGGER:* \`${closedByName}\`
+*DETAILS:*
+Ticket closed: *${ticket.ticketNumber}*
+• Customer: ${customerName}
+• Closed by: ${closedByName}
+*TIMESTAMP:* \`${this.nowInWAT()} (WAT)\``;
   }
 
   // Used by sendMessage — resolves to a ticket without ever silently
@@ -195,7 +269,22 @@ export class ChatService {
     ticket.closedBy = { id: closedByAdminId } as User;
 
     const saved = await this.ticketRepo.save(ticket);
-    return this.toResponseDto(saved, true);
+
+    // Same reason as createTicket — the bare { id } stub above has no
+    // firstName/surname loaded, so re-fetch to get the real closedBy name
+    // for the Slack notification.
+    const withRelations = await this.ticketRepo.findOne({
+      where: { id: saved.id },
+      relations: ['customer', 'assignedAdmin', 'closedBy'],
+    });
+    const dto = await this.toResponseDto(withRelations!, true);
+
+    const closedByName = withRelations!.closedBy
+      ? `${withRelations!.closedBy.firstName ?? ''} ${withRelations!.closedBy.surname ?? ''}`.trim() || 'Unknown'
+      : 'Unknown';
+    this.slackService.notify(this.formatTicketClosedSlackMessage(dto, closedByName));
+
+    return dto;
   }
 
   // Case-insensitive — an admin searching by number may have gotten it

--- a/src/admin/live-chat/chat.service.ts
+++ b/src/admin/live-chat/chat.service.ts
@@ -1,13 +1,16 @@
-import { Injectable } from '@nestjs/common';
-import { Repository } from 'typeorm';
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { ILike, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { ChatMessage } from 'src/all_user_entities/chat-message.entity';
 import { UserStatus } from 'src/all_user_entities/user-status.entity';
 import { User } from 'src/all_user_entities/user.entity';
-import { ChatMessageResponseDto, ChatUserInfoDto } from './send-message.dto';
+import { Ticket, TicketStatus } from 'src/all_user_entities/ticket.entity';
+import { ChatMessageResponseDto, ChatUserInfoDto, StaffContactDto, TicketResponseDto } from './send-message.dto';
 import { Appointment } from 'src/business/entities/appointment.entity';
 import { Business } from 'src/business/entities/business.entity';
+
+const TICKET_NUMBER_SEQUENCE = 'ticket_number_seq';
 
 export interface ChatListItem {
   userId: string;
@@ -35,10 +38,17 @@ export class ChatService {
 
     @InjectRepository(UserStatus)
     private statusRepo: Repository<UserStatus>,
+
+    @InjectRepository(User)
+    private userRepo: Repository<User>,
+
+    @InjectRepository(Ticket)
+    private ticketRepo: Repository<Ticket>,
   ) {}
 
   // Store a new message
   async storeMessage(data: {
+    ticket?: Ticket;
     sender: User;
     receiver: User;
     message?: string;
@@ -46,6 +56,177 @@ export class ChatService {
   }): Promise<ChatMessage> {
     const msg = this.chatRepo.create(data);
     return this.chatRepo.save(msg);
+  }
+
+  // ─── Tickets ────────────────────────────────────────────────────────────
+
+  // Sequential, human-searchable ticket numbers (TCK-1001, TCK-1002, ...).
+  // Uses a real Postgres sequence so concurrent ticket creation can never
+  // collide — created once, idempotently, the first time it's needed.
+  private async nextTicketNumber(): Promise<string> {
+    await this.ticketRepo.query(
+      `CREATE SEQUENCE IF NOT EXISTS ${TICKET_NUMBER_SEQUENCE} START 1001`,
+    );
+    const [{ nextval }] = await this.ticketRepo.query(
+      `SELECT nextval('${TICKET_NUMBER_SEQUENCE}') AS nextval`,
+    );
+    return `TCK-${nextval}`;
+  }
+
+  // Never return the raw Ticket entity from a controller — its customer/
+  // assignedAdmin/closedBy relations are full User rows (password hash
+  // included). This is the only shape that should leave the service.
+  // withCustomerSummary is only needed by admin-facing listing/search, not
+  // the customer widget's own findOrCreateOpenTicket/closeTicket calls.
+  private async toResponseDto(
+    ticket: Ticket,
+    withCustomerSummary = false,
+  ): Promise<TicketResponseDto> {
+    const dto: TicketResponseDto = {
+      id: ticket.id,
+      ticketNumber: ticket.ticketNumber,
+      status: ticket.status,
+      customerId: ticket.customer.id,
+      assignedAdminId: ticket.assignedAdmin?.id ?? null,
+      closedById: ticket.closedBy?.id ?? null,
+      closedAt: ticket.closedAt ? ticket.closedAt.toISOString() : null,
+      createdAt: ticket.createdAt.toISOString(),
+      updatedAt: ticket.updatedAt.toISOString(),
+    };
+
+    if (withCustomerSummary) {
+      const isOnline = await this.getUserStatus(ticket.customer.id);
+      const name =
+        `${ticket.customer.firstName ?? ''} ${ticket.customer.surname ?? ''}`.trim() ||
+        'Unknown';
+      dto.customer = { name, avatarUrl: ticket.customer.avatarUrl ?? null, isOnline };
+
+      const lastMessage = await this.chatRepo.findOne({
+        where: { ticket: { id: ticket.id } },
+        order: { createdAt: 'DESC' },
+      });
+      dto.lastMessage = lastMessage
+        ? lastMessage.message || (lastMessage.imageUrl ? '[Image]' : '')
+        : null;
+    }
+
+    return dto;
+  }
+
+  static readonly MAX_OPEN_TICKETS_PER_CUSTOMER = 2;
+
+  // All of this customer's currently-open tickets (0, 1, or up to the cap).
+  async getMyOpenTickets(customerId: string): Promise<TicketResponseDto[]> {
+    const tickets = await this.ticketRepo.find({
+      where: { customer: { id: customerId }, status: TicketStatus.OPEN },
+      relations: ['customer', 'assignedAdmin', 'closedBy'],
+      order: { createdAt: 'DESC' },
+    });
+    return Promise.all(tickets.map((t) => this.toResponseDto(t)));
+  }
+
+  // Creates a new ticket for this customer — but only if they're under the
+  // open-ticket cap. Enforced here, not just in the UI, since sendMessage
+  // also goes through this path. assignedAdminId records who the customer
+  // picked from "Talk to our team" — the frontend needs this to restore
+  // who a resumed ticket's conversation is with.
+  async createTicket(
+    customerId: string,
+    assignedAdminId?: string,
+  ): Promise<TicketResponseDto> {
+    const openCount = await this.ticketRepo.count({
+      where: { customer: { id: customerId }, status: TicketStatus.OPEN },
+    });
+
+    if (openCount >= ChatService.MAX_OPEN_TICKETS_PER_CUSTOMER) {
+      throw new BadRequestException(
+        `You already have ${ChatService.MAX_OPEN_TICKETS_PER_CUSTOMER} open conversations. Close one before starting another.`,
+      );
+    }
+
+    const ticketNumber = await this.nextTicketNumber();
+    const ticket = this.ticketRepo.create({
+      ticketNumber,
+      customer: { id: customerId } as User,
+      assignedAdmin: assignedAdminId ? ({ id: assignedAdminId } as User) : undefined,
+      status: TicketStatus.OPEN,
+    });
+
+    const saved = await this.ticketRepo.save(ticket);
+    saved.customer = { id: customerId } as User;
+    if (assignedAdminId) saved.assignedAdmin = { id: assignedAdminId } as User;
+    return this.toResponseDto(saved);
+  }
+
+  // Used by sendMessage — resolves to a ticket without ever silently
+  // creating a second one when the caller didn't ask for that. If the
+  // customer has exactly one open ticket, use it. If they have none,
+  // create one (respecting the cap, though 0 -> 1 never hits it). If they
+  // have more than one open, the caller MUST specify which ticket via
+  // ticketId — sendMessage enforces this before calling here.
+  async getSingleOpenTicketOrCreate(customerId: string): Promise<TicketResponseDto> {
+    const open = await this.getMyOpenTickets(customerId);
+    if (open.length === 1) return open[0];
+    if (open.length === 0) return this.createTicket(customerId);
+    throw new BadRequestException(
+      'You have multiple open conversations — specify which ticket this message belongs to.',
+    );
+  }
+
+  async getTicketById(ticketId: string): Promise<TicketResponseDto | null> {
+    const ticket = await this.ticketRepo.findOne({
+      where: { id: ticketId },
+      relations: ['customer', 'assignedAdmin', 'closedBy'],
+    });
+    return ticket ? this.toResponseDto(ticket) : null;
+  }
+
+  async closeTicket(ticketId: string, closedByAdminId: string): Promise<TicketResponseDto> {
+    const ticket = await this.ticketRepo.findOne({
+      where: { id: ticketId },
+      relations: ['customer', 'assignedAdmin', 'closedBy'],
+    });
+    if (!ticket) {
+      throw new BadRequestException('Ticket not found');
+    }
+
+    ticket.status = TicketStatus.CLOSED;
+    ticket.closedAt = new Date();
+    ticket.closedBy = { id: closedByAdminId } as User;
+
+    const saved = await this.ticketRepo.save(ticket);
+    return this.toResponseDto(saved, true);
+  }
+
+  // Case-insensitive — an admin searching by number may have gotten it
+  // from a screenshot, an email, or dictated over the phone, and shouldn't
+  // hit a false "not found" over casing alone.
+  async getTicketByNumber(ticketNumber: string): Promise<TicketResponseDto | null> {
+    const ticket = await this.ticketRepo.findOne({
+      where: { ticketNumber: ILike(ticketNumber.trim()) },
+      relations: ['customer', 'assignedAdmin', 'closedBy'],
+    });
+    return ticket ? this.toResponseDto(ticket, true) : null;
+  }
+
+  async listTickets(status: TicketStatus): Promise<TicketResponseDto[]> {
+    const tickets = await this.ticketRepo.find({
+      where: { status },
+      relations: ['customer', 'assignedAdmin', 'closedBy'],
+      order: { createdAt: 'DESC' },
+    });
+    return Promise.all(tickets.map((t) => this.toResponseDto(t, true)));
+  }
+
+  // The customer's own ticket history — every ticket they've ever opened,
+  // not just the currently-open one findOrCreateOpenTicket resumes.
+  async listMyTickets(customerId: string): Promise<TicketResponseDto[]> {
+    const tickets = await this.ticketRepo.find({
+      where: { customer: { id: customerId } },
+      relations: ['customer', 'assignedAdmin', 'closedBy'],
+      order: { createdAt: 'DESC' },
+    });
+    return Promise.all(tickets.map((t) => this.toResponseDto(t)));
   }
 
   // Get user online/offline status
@@ -87,6 +268,25 @@ export class ChatService {
     return msg;
   }
 
+  // Mark every message the other party sent to this user as read (called
+  // when the user opens/reselects that conversation).
+  async markConversationAsRead(userId: string, otherUserId: string) {
+    const unread = await this.chatRepo.find({
+      where: {
+        sender: { id: otherUserId },
+        receiver: { id: userId },
+        read: false,
+      },
+    });
+
+    if (unread.length === 0) return;
+
+    await this.chatRepo.update(
+      unread.map((msg) => msg.id),
+      { read: true },
+    );
+  }
+
   // Get all messages between two users
   async getMessagesBetween(userId1: string, userId2: string): Promise<ChatMessage[]> {
     return this.chatRepo.find({
@@ -96,6 +296,36 @@ export class ChatService {
       ],
       order: { createdAt: 'ASC' },
     });
+  }
+
+  // Staff a customer can start a new conversation with — separate from
+  // getChatList, which only shows conversations that already have messages.
+  async getAllStaffContacts(): Promise<StaffContactDto[]> {
+    const staff = await this.userRepo.find({ where: { isStaff: true } });
+
+    const contacts: StaffContactDto[] = [];
+    for (const member of staff) {
+      const isOnline = await this.getUserStatus(member.id);
+      const name = `${member.firstName ?? ''} ${member.surname ?? ''}`.trim() || 'Admin';
+      const initials = name
+        .split(' ')
+        .map((n) => n.charAt(0).toUpperCase())
+        .join('')
+        .toUpperCase();
+
+      contacts.push({
+        id: member.id,
+        name,
+        avatarUrl: member.avatarUrl,
+        initials,
+        email: member.email,
+        phone: member.phoneNumber,
+        isOnline,
+        lastSeen: member.createdAt.toISOString(),
+      });
+    }
+
+    return contacts;
   }
 
   // Get chat list for the signed-in user
@@ -171,6 +401,7 @@ export class ChatService {
       .toLocaleUpperCase();
 
     return {
+      userId: user.id,
       name,
       initials,
       email: user.email,
@@ -183,26 +414,18 @@ export class ChatService {
     };
   }
 
-  async getChatMessageWithUserInfo(
-    authUserId: string, 
-    otherUserId: string
+  // Shared by both getChatMessageWithUserInfo and getMessagesByTicket —
+  // enriches a set of already-fetched messages with booking counts and
+  // business ratings for whichever users appear in them.
+  private async toMessageResponseDtos(
+    messages: ChatMessage[],
   ): Promise<ChatMessageResponseDto[]> {
-    
-    // Fetch messages only between the two users
-    const messages = await this.chatRepo
-      .createQueryBuilder('msg')
-      .leftJoinAndSelect('msg.sender', 'sender')
-      .leftJoinAndSelect('msg.receiver', 'receiver')
-      .where(
-        '(sender.id = :authUserId AND receiver.id = :otherUserId) OR (sender.id = :otherUserId AND receiver.id = :authUserId)',
-        { authUserId, otherUserId }
-      )
-      .orderBy('msg.createdAt', 'ASC')
-      .getMany();
+    const userIds = Array.from(
+      new Set(messages.flatMap((m) => [m.sender.id, m.receiver.id])),
+    );
 
-    const userIds = [authUserId, otherUserId];
+    if (userIds.length === 0) return [];
 
-    // Booking counts for both users
     const bookingCounts = await this.appointmentRepo
       .createQueryBuilder('a')
       .select('a.client_id', 'clientId')
@@ -216,7 +439,6 @@ export class ChatService {
       return acc;
     }, {});
 
-    // Business ratings for both users
     const businessRatings = await this.businessRepo
       .createQueryBuilder('b')
       .select('b.owner_id', 'ownerId')
@@ -230,7 +452,6 @@ export class ChatService {
       return acc;
     }, {});
 
-    // Map messages to DTO
     return messages.map((msg) => ({
       id: msg.id,
       messages: msg.message,
@@ -248,5 +469,38 @@ export class ChatService {
         ratingMap[msg.receiver.id] || 0
       ),
     }));
+  }
+
+  async getChatMessageWithUserInfo(
+    authUserId: string,
+    otherUserId: string
+  ): Promise<ChatMessageResponseDto[]> {
+    // Fetch messages only between the two users
+    const messages = await this.chatRepo
+      .createQueryBuilder('msg')
+      .leftJoinAndSelect('msg.sender', 'sender')
+      .leftJoinAndSelect('msg.receiver', 'receiver')
+      .where(
+        '(sender.id = :authUserId AND receiver.id = :otherUserId) OR (sender.id = :otherUserId AND receiver.id = :authUserId)',
+        { authUserId, otherUserId }
+      )
+      .orderBy('msg.createdAt', 'ASC')
+      .getMany();
+
+    return this.toMessageResponseDtos(messages);
+  }
+
+  // Ticket-scoped — the real boundary a closed ticket needs. Messages sent
+  // before ticketing existed have no ticketId and never show up here.
+  async getMessagesByTicket(ticketId: string): Promise<ChatMessageResponseDto[]> {
+    const messages = await this.chatRepo
+      .createQueryBuilder('msg')
+      .leftJoinAndSelect('msg.sender', 'sender')
+      .leftJoinAndSelect('msg.receiver', 'receiver')
+      .where('msg.ticketId = :ticketId', { ticketId })
+      .orderBy('msg.createdAt', 'ASC')
+      .getMany();
+
+    return this.toMessageResponseDtos(messages);
   }
 }

--- a/src/admin/live-chat/send-message.dto.ts
+++ b/src/admin/live-chat/send-message.dto.ts
@@ -25,9 +25,19 @@ export class SendMessageDto {
   @IsOptional()
   @IsString()
   imageBase64?: string;
+
+  @ApiProperty({
+    description:
+      'Which ticket this message belongs to. Required when the customer has more than one open ticket (up to the 2-ticket cap) — optional otherwise, since there is only one possible ticket to resolve to.',
+    required: false,
+  })
+  @IsOptional()
+  @IsUUID()
+  ticketId?: string;
 }
 
 export class ChatUserInfoDto {
+  userId: string;
   name: string;
   avatarUrl?: string;
   initials: string;
@@ -47,4 +57,39 @@ export class ChatMessageResponseDto {
   createdAt: string;
   sender: ChatUserInfoDto;
   receiver: ChatUserInfoDto;
+}
+
+export class StaffContactDto {
+  id: string;
+  name: string;
+  avatarUrl?: string;
+  initials: string;
+  email: string;
+  phone?: string;
+  isOnline: boolean;
+  lastSeen?: string;
+}
+
+export class TicketCustomerSummaryDto {
+  name: string;
+  avatarUrl?: string | null;
+  isOnline: boolean;
+}
+
+// Never the raw User entity — that includes the password hash and other
+// sensitive fields. This is the only shape the ticket endpoints return.
+export class TicketResponseDto {
+  id: string;
+  ticketNumber: string;
+  status: 'open' | 'closed';
+  customerId: string;
+  assignedAdminId?: string | null;
+  closedById?: string | null;
+  closedAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  // Only populated by admin-facing listing/search methods — the customer
+  // widget's own findOrCreateOpenTicket/closeTicket calls don't need it.
+  customer?: TicketCustomerSummaryDto;
+  lastMessage?: string | null;
 }

--- a/src/admin/live-chat/send-message.dto.ts
+++ b/src/admin/live-chat/send-message.dto.ts
@@ -74,6 +74,8 @@ export class TicketCustomerSummaryDto {
   name: string;
   avatarUrl?: string | null;
   isOnline: boolean;
+  // Merchant tickets are surfaced as higher-priority in the Team Inbox.
+  isMerchant: boolean;
 }
 
 // Never the raw User entity — that includes the password hash and other

--- a/src/all_user_entities/chat-message.entity.ts
+++ b/src/all_user_entities/chat-message.entity.ts
@@ -7,11 +7,17 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { User } from 'src/all_user_entities/user.entity';
+import { Ticket } from 'src/all_user_entities/ticket.entity';
 
 @Entity('chat_messages')
 export class ChatMessage {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  // Nullable so pre-ticketing messages remain valid — every new message
+  // going forward is required (at the service layer) to have one.
+  @ManyToOne(() => Ticket, { nullable: true })
+  ticket?: Ticket;
 
   @ManyToOne(() => User)
   sender: User;

--- a/src/all_user_entities/ticket.entity.ts
+++ b/src/all_user_entities/ticket.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from 'src/all_user_entities/user.entity';
+
+export enum TicketStatus {
+  OPEN = 'open',
+  CLOSED = 'closed',
+}
+
+@Entity('tickets')
+export class Ticket {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', unique: true })
+  ticketNumber: string;
+
+  @ManyToOne(() => User)
+  customer: User;
+
+  @ManyToOne(() => User, { nullable: true })
+  assignedAdmin?: User;
+
+  @Column({ type: 'enum', enum: TicketStatus, default: TicketStatus.OPEN })
+  status: TicketStatus;
+
+  @ManyToOne(() => User, { nullable: true })
+  closedBy?: User;
+
+  @Column({ type: 'timestamp', nullable: true })
+  closedAt?: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';
 import { EmailModule } from './email/email.module';
+import { SlackModule } from './slack/slack.module';
 import { BusinessModule } from './business/business.module';
 import { AdminModule } from './admin/admin.module';
 import { GiftcardModule } from './admin/giftcard/admin_giftcard.module';
@@ -76,6 +77,7 @@ import { LandingModule } from './landing/landing.module';
     ]),
 
     EmailModule,
+    SlackModule,
     BusinessModule,
     AdminModule,
     GiftcardModule,

--- a/src/slack/slack.module.ts
+++ b/src/slack/slack.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { SlackService } from './slack.service';
+
+@Module({
+  providers: [SlackService],
+  exports: [SlackService],
+})
+export class SlackModule {}

--- a/src/slack/slack.service.ts
+++ b/src/slack/slack.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { WebClient } from '@slack/web-api';
+
+// #test-notifications — replaces Town Crier, whose access was revoked with
+// immediate effect.
+const NOTIFICATIONS_CHANNEL_ID = 'C0B9KDACX5G';
+
+@Injectable()
+export class SlackService {
+  private readonly logger = new Logger(SlackService.name);
+  private client: WebClient | null = null;
+
+  constructor(private readonly configService: ConfigService) {}
+
+  private getClient(): WebClient | null {
+    if (this.client) return this.client;
+
+    const token = this.configService.get<string>('SLACK_USERS_TOKEN');
+    if (!token) {
+      this.logger.warn('SLACK_USERS_TOKEN is not set — Slack notifications are disabled.');
+      return null;
+    }
+
+    this.client = new WebClient(token);
+    return this.client;
+  }
+
+  // Fire-and-forget by design — a Slack outage must never affect the
+  // request that triggered it (mirrors EmailService's sendWithRetry, which
+  // is also never awaited by its callers).
+  notify(message: string, channel: string = NOTIFICATIONS_CHANNEL_ID): void {
+    if (!channel) {
+      this.logger.warn('No Slack channel ID configured — notification skipped.');
+      return;
+    }
+
+    const client = this.getClient();
+    if (!client) return;
+
+    client.chat
+      .postMessage({
+        channel,
+        text: message,
+        username: 'KHS Support Alerts',
+        unfurl_links: false,
+      })
+      .then(() => this.logger.log(`Slack notification sent to ${channel}`))
+      .catch((err) => this.logger.error(`Slack notification failed: ${err.message}`));
+  }
+}


### PR DESCRIPTION
Summary
Extends ticket-based support chat to merchants (previously customer-only) — same 2-open-ticket cap, real-time messaging, ticket history.
Fixes new tickets requiring a hard refresh to appear in the Team Inbox by broadcasting a ticket_created socket event, mirroring the existing ticket_closed event.
Fixes createTicket/closeTicket responses returning "Unknown" as the customer name and an incorrect merchant flag — both were building the response from an unloaded relation stub instead of re-fetching with relations.
Adds isMerchant to the ticket customer summary DTO so merchant tickets can be flagged and prioritized in the admin inbox.
Adds a minimal SlackService/SlackModule that posts to #test-notifications on ticket creation and closure (ticket number, customer, assigned admin / closed-by admin).
Adds seed scripts for a test merchant (with a linked, pre-approved business record) and test customer account for local dev login.
