### PR TITLE
Feat- ADJ- stripe escrow payments 2026 08 06

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,13 @@ PAYSTACK_SECRET_KEY=your_paystack_secret_key
 PAYSTACK_BASE_URL=https://api.paystack.co
 
 # ============================================
+# STRIPE
+# ============================================
+STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key
+STRIPE_WEBHOOK_SECRET=whsec_your_stripe_webhook_secret
+STRIPE_PUBLISHABLE_KEY=pk_test_your_stripe_publishable_key
+
+# ============================================
 # CLOUDINARY (User Uploads)
 # ============================================
 CLOUDINARY_CLOUD_NAME=your_cloudinary_cloud_name

--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,27 @@ CLOUDINARY_API_KEY=your_cloudinary_api_key
 CLOUDINARY_API_SECRET=your_cloudinary_api_secret
 
 # ============================================
+# FIREBASE (User Uploads — shared c2c Firebase project/bucket)
+# ============================================
+# Values come from Firebase Console > Project Settings > Service Accounts >
+# "Generate new private key" (downloads one JSON file — each field below
+# maps 1:1 to a field in that file). FIREBASE_STORAGE_BUCKET comes from
+# Firebase Console > Storage instead (not part of the JSON file).
+# NEVER commit real values here — this file only documents the shape.
+FIREBASE_TYPE=service_account
+FIREBASE_PROJECT_ID=your_firebase_project_id
+FIREBASE_PRIVATE_KEY_ID=your_firebase_private_key_id
+FIREBASE_PRIVATE_KEY="your_firebase_private_key"
+FIREBASE_CLIENT_EMAIL=your_firebase_client_email
+FIREBASE_CLIENT_ID=your_firebase_client_id
+FIREBASE_AUTH_URI=https://accounts.google.com/o/oauth2/auth
+FIREBASE_TOKEN_URI=https://oauth2.googleapis.com/token
+FIREBASE_AUTH_PROVIDER_X509_CERT_URL=https://www.googleapis.com/oauth2/v1/certs
+FIREBASE_CLIENT_X509_CERT_URL=your_firebase_client_x509_cert_url
+FIREBASE_UNIVERSEDOMAIN=googleapis.com
+FIREBASE_STORAGE_BUCKET=your_firebase_storage_bucket
+
+# ============================================
 # PLATFORM SETTINGS ENCRYPTION (Admin Integration Secrets)
 # ============================================
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"

--- a/scripts/seed-common-salons.ts
+++ b/scripts/seed-common-salons.ts
@@ -1,0 +1,181 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import * as dotenv from 'dotenv';
+import * as bcrypt from 'bcrypt';
+
+dotenv.config();
+
+// 10 new, ordinary (non-luxury) salons for testing the /customer/salons
+// mixed-grid layout — deliberately kept under the 4.5 luxury rating
+// threshold and with no luxuryOverride set, so they land in the plain
+// "All salons" grid, not the featured luxury strip.
+
+const businessImages = [
+  'https://images.unsplash.com/photo-1560066984-138dadb4c035?w=800',
+  'https://images.unsplash.com/photo-1522337360788-8b13dee7a37e?w=800',
+  'https://images.unsplash.com/photo-1633681926022-84c23e8cb2d6?w=800',
+  'https://images.unsplash.com/photo-1521590832167-7bcbfaa6381f?w=800',
+  'https://images.unsplash.com/photo-1600948836101-f9ffda59d250?w=800',
+];
+
+const businessNames = [
+  'Glamour Hair Studio',
+  'The Hair Lounge',
+  'Curls & Coils Salon',
+  'Urban Cuts Barbershop',
+  'Serene Nails & Beauty',
+  'The Style House',
+  'Elite Hair Designs',
+  'Bloom Beauty Studio',
+  'Trendsetters Hair Co.',
+  'The Beauty Bar',
+];
+
+const cities = [
+  { name: 'Lagos', coords: { lat: 6.5244, lng: 3.3792 } },
+  { name: 'Abuja', coords: { lat: 9.0765, lng: 7.4983 } },
+  { name: 'Port Harcourt', coords: { lat: 4.8156, lng: 7.0498 } },
+  { name: 'Ibadan', coords: { lat: 7.3775, lng: 3.947 } },
+  { name: 'Kano', coords: { lat: 12.0022, lng: 8.5919 } },
+];
+
+const addresses = [
+  '15 Admiralty Way, Lekki Phase 1',
+  '42 Awoyaya Road, Ajah',
+  '78 Allen Avenue, Ikeja',
+  '23 Adeniran Ogunsanya, Surulere',
+  '56 Bourdillon Road, Ikoyi',
+  '31 Kaduna Street, Maitama',
+  '12 Wuse 2, Abuja',
+  '45 Trans Amadi, Port Harcourt',
+  '89 Ring Road, Ibadan',
+  '34 Bompai Road, Kano',
+];
+
+const staffFirstNames = [
+  'Adaobi', 'Chinedu', 'Folake', 'Oluwaseun', 'Ngozi',
+  'Emeka', 'Amina', 'Tunde', 'Chisom', 'Ifeanyi',
+];
+
+const staffLastNames = [
+  'Okonkwo', 'Okafor', 'Adeyemi', 'Eze', 'Balogun',
+  'Ibrahim', 'Oyelaran', 'Nwosu', 'Adewale', 'Musah',
+];
+
+const categories = ['hair-services', 'nail-services', 'spa-treatments', 'barbering', 'skincare'];
+const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+const AppDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DB_HOST ?? 'localhost',
+  port: parseInt(process.env.DB_PORT ?? '5432', 10),
+  username: process.env.DB_USERNAME ?? 'postgres',
+  password: process.env.DB_PASSWORD ?? 'password',
+  database: process.env.DB_DATABASE ?? 'kinky_hair_stylist',
+});
+
+async function seed() {
+  await AppDataSource.initialize();
+  console.log('Database connected');
+
+  const hashedPassword = await bcrypt.hash('password123', 10);
+  const nameList = businessNames.map((n) => `'${n.replace(/'/g, "''")}'`).join(',');
+
+  console.log('Cleaning up any prior run of this seed...');
+  try {
+    await AppDataSource.query(
+      `DELETE FROM booking_days WHERE "businessId" IN (SELECT id FROM businesses WHERE "businessName" IN (${nameList}))`,
+    );
+  } catch (e) {}
+  try {
+    await AppDataSource.query(
+      `DELETE FROM businesses WHERE "businessName" IN (${nameList})`,
+    );
+  } catch (e) {}
+  try {
+    await AppDataSource.query(
+      `DELETE FROM "user" WHERE email LIKE 'commonowner%@khs-common.local'`,
+    );
+  } catch (e) {}
+
+  for (let i = 0; i < businessNames.length; i++) {
+    const cityIndex = i % cities.length;
+    const addressIndex = i % addresses.length;
+
+    const userResult = await AppDataSource.query(
+      `INSERT INTO "user" (
+        email, password, "firstName", surname, "phoneNumber",
+        "isVerified", "isClient", "isBusiness", "createdAt", "updatedAt"
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW()) RETURNING id`,
+      [
+        `commonowner${i + 1}@khs-common.local`,
+        hashedPassword,
+        staffFirstNames[i % staffFirstNames.length],
+        staffLastNames[i % staffLastNames.length],
+        `+23482${String(i).padStart(8, '0')}`,
+        true,
+        true,
+        true,
+      ],
+    );
+    const ownerId = userResult[0].id;
+
+    // Rating deliberately kept in the 3.5-4.4 band — real variety, but
+    // always below the 4.5 luxury auto-qualify threshold.
+    const rating = +(3.5 + Math.random() * 0.9).toFixed(1);
+
+    const businessResult = await AppDataSource.query(
+      `INSERT INTO businesses (
+        "businessName", description, "owner_id", "ownerName", "ownerEmail", "ownerPhone",
+        "primaryAudience", "businessAddress", "businessImage", longitude, latitude,
+        "companySize", status, category, plan, performance, revenue, bookings, "createdAt", "updatedAt"
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, 0, 0, NOW(), NOW()) RETURNING id`,
+      [
+        businessNames[i],
+        `Welcome to ${businessNames[i]}! We offer quality beauty and grooming services in ${cities[cityIndex].name}.`,
+        ownerId,
+        `${staffFirstNames[i % staffFirstNames.length]} ${staffLastNames[i % staffLastNames.length]}`,
+        `commonowner${i + 1}@khs-common.local`,
+        `+23482${String(i).padStart(8, '0')}`,
+        'Everyone looking for quality beauty services',
+        `${addresses[addressIndex]}, ${cities[cityIndex].name}`,
+        JSON.stringify([
+          businessImages[i % businessImages.length],
+          businessImages[(i + 1) % businessImages.length],
+        ]),
+        cities[cityIndex].coords.lng + (Math.random() * 0.1 - 0.05),
+        cities[cityIndex].coords.lat + (Math.random() * 0.1 - 0.05),
+        'small-team',
+        'approved',
+        JSON.stringify([categories[i % categories.length], categories[(i + 1) % categories.length]]),
+        'Free',
+        JSON.stringify({
+          rating,
+          reviews: Math.floor(5 + Math.random() * 60),
+          completionRate: +(80 + Math.random() * 15).toFixed(0),
+          avgResponseMins: Math.floor(15 + Math.random() * 60),
+        }),
+      ],
+    );
+    const businessId = businessResult[0].id;
+
+    for (const day of days) {
+      await AppDataSource.query(
+        `INSERT INTO booking_days (day, "isOpen", "startTime", "endTime", "businessId") VALUES ($1, $2, $3, $4, $5)`,
+        [day, day !== 'Sunday', day === 'Saturday' ? '10:00' : '09:00', day === 'Saturday' ? '18:00' : '19:00', businessId],
+      );
+    }
+
+    console.log(`Created common salon ${i + 1}: ${businessNames[i]} (rating ${rating})`);
+  }
+
+  console.log('\n=== Seeding Complete ===');
+  console.log('Created 10 common (non-luxury) salons, all APPROVED.');
+
+  await AppDataSource.destroy();
+}
+
+seed().catch((error) => {
+  console.error('Seeding failed:', error);
+  process.exit(1);
+});

--- a/scripts/seed-global-salons-with-services.ts
+++ b/scripts/seed-global-salons-with-services.ts
@@ -1,0 +1,307 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import * as dotenv from 'dotenv';
+import * as bcrypt from 'bcrypt';
+
+dotenv.config();
+
+// International (non-Nigerian) salons — mix of luxury and non-luxury —
+// each with real bookable Service rows attached. The earlier
+// seed-global-salons.ts created businesses only, no services, which is
+// why location coverage looked fine on the salons grid but empty on
+// anything that lists services (booking flow, service search). This
+// script seeds both together so a business seeded here is immediately
+// bookable, not just visible.
+
+const businessImages = [
+  'https://images.unsplash.com/photo-1560066984-138dadb4c035?w=800',
+  'https://images.unsplash.com/photo-1522337360788-8b13dee7a37e?w=800',
+  'https://images.unsplash.com/photo-1633681926022-84c23e8cb2d6?w=800',
+  'https://images.unsplash.com/photo-1521590832167-7bcbfaa6381f?w=800',
+  'https://images.unsplash.com/photo-1600948836101-f9ffda59d250?w=800',
+];
+
+const categories = ['hair-services', 'nail-services', 'spa-treatments', 'barbering', 'skincare', 'makeup-services', 'lashes-brows', 'body-care'];
+const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+// category -> service types that belong to it (mirrors service-type.enum.ts)
+const servicesByCategory: Record<string, { type: string; name: string }[]> = {
+  'hair-services': [
+    { type: 'women-haircut', name: "Women's Haircut & Style" },
+    { type: 'men-haircut', name: "Men's Haircut" },
+    { type: 'hair-coloring', name: 'Full Hair Coloring' },
+    { type: 'hair-treatment', name: 'Deep Conditioning Treatment' },
+    { type: 'blow-dry', name: 'Blow Dry & Finish' },
+    { type: 'braiding', name: 'Protective Braiding' },
+  ],
+  'nail-services': [
+    { type: 'manicure', name: 'Classic Manicure' },
+    { type: 'pedicure', name: 'Spa Pedicure' },
+    { type: 'gel-polish', name: 'Gel Polish' },
+    { type: 'acrylic-nails', name: 'Acrylic Nail Extensions' },
+  ],
+  'makeup-services': [
+    { type: 'bridal-makeup', name: 'Bridal Makeup' },
+    { type: 'party-makeup', name: 'Party Glam Makeup' },
+    { type: 'natural-glam', name: 'Natural Everyday Glam' },
+  ],
+  'spa-treatments': [
+    { type: 'facial', name: 'Rejuvenating Facial' },
+    { type: 'body-scrub', name: 'Exfoliating Body Scrub' },
+    { type: 'massage', name: 'Relaxation Massage' },
+  ],
+  barbering: [
+    { type: 'men-haircut', name: "Men's Signature Cut" },
+    { type: 'beard-trim', name: 'Beard Trim & Shape' },
+    { type: 'fade-cut', name: 'Skin Fade' },
+  ],
+  skincare: [
+    { type: 'deep-cleansing-facial', name: 'Deep Cleansing Facial' },
+    { type: 'acne-treatment', name: 'Acne Treatment' },
+  ],
+  'lashes-brows': [
+    { type: 'lash-extension', name: 'Lash Extensions' },
+    { type: 'brow-shaping', name: 'Brow Shaping' },
+    { type: 'brow-tint', name: 'Brow Tint' },
+  ],
+  'body-care': [
+    { type: 'waxing', name: 'Full Body Waxing' },
+    { type: 'body-polish', name: 'Body Polish' },
+  ],
+};
+
+interface CityDef {
+  city: string;
+  state: string;
+  country: string;
+  lat: number;
+  lng: number;
+}
+
+const AU: CityDef[] = [
+  { city: 'Sydney', state: 'NSW', country: 'Australia', lat: -33.8688, lng: 151.2093 },
+  { city: 'Melbourne', state: 'VIC', country: 'Australia', lat: -37.8136, lng: 144.9631 },
+  { city: 'Brisbane', state: 'QLD', country: 'Australia', lat: -27.4698, lng: 153.0251 },
+  { city: 'Perth', state: 'WA', country: 'Australia', lat: -31.9505, lng: 115.8605 },
+];
+
+const US: CityDef[] = [
+  { city: 'New York', state: 'NY', country: 'USA', lat: 40.7128, lng: -74.006 },
+  { city: 'Los Angeles', state: 'CA', country: 'USA', lat: 34.0522, lng: -118.2437 },
+  { city: 'Houston', state: 'TX', country: 'USA', lat: 29.7604, lng: -95.3698 },
+  { city: 'Miami', state: 'FL', country: 'USA', lat: 25.7617, lng: -80.1918 },
+  { city: 'Chicago', state: 'IL', country: 'USA', lat: 41.8781, lng: -87.6298 },
+];
+
+const UK: CityDef[] = [
+  { city: 'London', state: 'England', country: 'UK', lat: 51.5072, lng: -0.1276 },
+  { city: 'Manchester', state: 'England', country: 'UK', lat: 53.4808, lng: -2.2426 },
+  { city: 'Edinburgh', state: 'Scotland', country: 'UK', lat: 55.9533, lng: -3.1883 },
+  { city: 'Cardiff', state: 'Wales', country: 'UK', lat: 51.4816, lng: -3.1791 },
+];
+
+const CA: CityDef[] = [
+  { city: 'Toronto', state: 'ON', country: 'Canada', lat: 43.6532, lng: -79.3832 },
+  { city: 'Vancouver', state: 'BC', country: 'Canada', lat: 49.2827, lng: -123.1207 },
+  { city: 'Montreal', state: 'QC', country: 'Canada', lat: 45.5019, lng: -73.5674 },
+];
+
+const AE: CityDef[] = [
+  { city: 'Dubai', state: 'Dubai', country: 'UAE', lat: 25.2048, lng: 55.2708 },
+  { city: 'Abu Dhabi', state: 'Abu Dhabi', country: 'UAE', lat: 24.4539, lng: 54.3773 },
+];
+
+const ZA: CityDef[] = [
+  { city: 'Johannesburg', state: 'Gauteng', country: 'South Africa', lat: -26.2041, lng: 28.0473 },
+  { city: 'Cape Town', state: 'Western Cape', country: 'South Africa', lat: -33.9249, lng: 18.4241 },
+];
+
+// 4 per group, 6 groups = 24 businesses. Half will roll >=4.5 (luxury),
+// half below, via the rating distribution below — deliberate, not random
+// chance, so we always get a real mix regardless of Math.random() luck.
+const cityGroups: { cities: CityDef[]; count: number }[] = [
+  { cities: AU, count: 4 },
+  { cities: US, count: 4 },
+  { cities: UK, count: 4 },
+  { cities: CA, count: 4 },
+  { cities: AE, count: 4 },
+  { cities: ZA, count: 4 },
+];
+
+const nameTemplates = [
+  'Radiant Hair Studio', 'The Braid House', 'Curl & Co.', 'Silk Strands Salon',
+  'Golden Comb Barbershop', 'Velvet Roots', 'The Glow Parlour', 'Twist & Shine',
+  'Crown Beauty Bar', 'Mane Attraction', 'The Loc Lounge', 'Polished Beauty Studio',
+  'Coco Curls', 'Sunset Salon & Spa', 'Elevate Hair Co.', 'The Style Foundry',
+  'Bare Beauty Bar', 'Prime Cuts Barbershop', 'Halo Hair Studio', 'The Vanity Room',
+  'Muse Salon', 'Onyx Hair Lounge', 'Radiance Beauty Studio', 'The Grooming Room',
+];
+
+const staffFirstNames = ['Alex', 'Jordan', 'Taylor', 'Morgan', 'Casey', 'Riley', 'Sam', 'Jamie', 'Drew', 'Skyler'];
+const staffLastNames = ['Smith', 'Johnson', 'Williams', 'Brown', 'Jones', 'Miller', 'Davis', 'Wilson', 'Taylor', 'Clark'];
+
+const AppDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DB_HOST ?? 'localhost',
+  port: parseInt(process.env.DB_PORT ?? '5432', 10),
+  username: process.env.DB_USERNAME ?? 'postgres',
+  password: process.env.DB_PASSWORD ?? 'password',
+  database: process.env.DB_DATABASE ?? 'kinky_hair_stylist',
+  ssl: process.env.DB_SSL === 'require' ? { rejectUnauthorized: false } : false,
+});
+
+function randomPrice(min: number, max: number): number {
+  return +(min + Math.random() * (max - min)).toFixed(2);
+}
+
+async function seed() {
+  await AppDataSource.initialize();
+  console.log(`Database connected: ${process.env.DB_HOST}/${process.env.DB_DATABASE}`);
+
+  const hashedPassword = await bcrypt.hash('password123', 10);
+  const nameList = nameTemplates.map((n) => `'${n.replace(/'/g, "''")}'`).join(',');
+
+  console.log('Cleaning up any prior run of this seed...');
+  try {
+    await AppDataSource.query(
+      `DELETE FROM "Service" WHERE "businessId" IN (SELECT id FROM businesses WHERE "businessName" IN (${nameList}) AND "ownerEmail" LIKE '%@khs-global2.local')`,
+    );
+  } catch (e) {}
+  try {
+    await AppDataSource.query(
+      `DELETE FROM booking_days WHERE "businessId" IN (SELECT id FROM businesses WHERE "businessName" IN (${nameList}) AND "ownerEmail" LIKE '%@khs-global2.local')`,
+    );
+  } catch (e) {}
+  try {
+    await AppDataSource.query(
+      `DELETE FROM businesses WHERE "businessName" IN (${nameList}) AND "ownerEmail" LIKE '%@khs-global2.local'`,
+    );
+  } catch (e) {}
+  try {
+    await AppDataSource.query(`DELETE FROM "user" WHERE email LIKE 'globalowner2_%@khs-global2.local'`);
+  } catch (e) {}
+
+  let nameIdx = 0;
+  let created = 0;
+  let servicesCreated = 0;
+
+  for (const group of cityGroups) {
+    for (let i = 0; i < group.count; i++) {
+      const city = group.cities[i % group.cities.length];
+      const name = nameTemplates[nameIdx % nameTemplates.length];
+      nameIdx++;
+
+      const userResult = await AppDataSource.query(
+        `INSERT INTO "user" (
+          email, password, "firstName", surname, "phoneNumber",
+          "isVerified", "isMerchant", "createdAt", "updatedAt"
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW()) RETURNING id`,
+        [
+          `globalowner2_${created + 1}@khs-global2.local`,
+          hashedPassword,
+          staffFirstNames[created % staffFirstNames.length],
+          staffLastNames[created % staffLastNames.length],
+          `+1${String(2000000000 + created).padStart(10, '0')}`,
+          true,
+          true,
+        ],
+      );
+      const ownerId = userResult[0].id;
+
+      // Deliberate split: even index in the group -> luxury (>=4.5),
+      // odd index -> non-luxury (3.5-4.4). Not left to Math.random() luck.
+      const isLuxuryRow = i % 2 === 0;
+      const rating = isLuxuryRow
+        ? +(4.5 + Math.random() * 0.5).toFixed(1)
+        : +(3.5 + Math.random() * 0.9).toFixed(1);
+
+      const catA = categories[created % categories.length];
+      const catB = categories[(created + 3) % categories.length];
+
+      const businessResult = await AppDataSource.query(
+        `INSERT INTO businesses (
+          "businessName", description, "owner_id", "ownerName", "ownerEmail", "ownerPhone",
+          "primaryAudience", "businessAddress", "businessImage", longitude, latitude,
+          "companySize", status, category, plan, performance, revenue, bookings, "createdAt", "updatedAt"
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, 0, 0, NOW(), NOW()) RETURNING id`,
+        [
+          name,
+          `Welcome to ${name}! We offer premium beauty and grooming services in ${city.city}, ${city.state}.`,
+          ownerId,
+          `${staffFirstNames[created % staffFirstNames.length]} ${staffLastNames[created % staffLastNames.length]}`,
+          `globalowner2_${created + 1}@khs-global2.local`,
+          `+1${String(2000000000 + created).padStart(10, '0')}`,
+          'Everyone looking for quality beauty services',
+          `${100 + created} High Street, ${city.state}, ${city.city}`,
+          JSON.stringify([
+            businessImages[created % businessImages.length],
+            businessImages[(created + 1) % businessImages.length],
+          ]),
+          city.lng + (Math.random() * 0.05 - 0.025),
+          city.lat + (Math.random() * 0.05 - 0.025),
+          'small-team',
+          'approved',
+          JSON.stringify([catA, catB]),
+          'Free',
+          JSON.stringify({
+            rating,
+            reviews: Math.floor(10 + Math.random() * 150),
+            completionRate: +(85 + Math.random() * 15).toFixed(0),
+            avgResponseMins: Math.floor(10 + Math.random() * 50),
+          }),
+        ],
+      );
+      const businessId = businessResult[0].id;
+
+      for (const day of days) {
+        await AppDataSource.query(
+          `INSERT INTO booking_days (day, "isOpen", "startTime", "endTime", "businessId") VALUES ($1, $2, $3, $4, $5)`,
+          [day, day !== 'Sunday', day === 'Saturday' ? '10:00' : '09:00', day === 'Saturday' ? '18:00' : '19:00', businessId],
+        );
+      }
+
+      // 2-3 services per business, drawn from each of its 2 categories.
+      const servicePool = [
+        ...(servicesByCategory[catA] ?? []).map((s) => ({ ...s, category: catA })),
+        ...(servicesByCategory[catB] ?? []).map((s) => ({ ...s, category: catB })),
+      ];
+      const serviceCount = Math.min(servicePool.length, 2 + (created % 2));
+      for (let s = 0; s < serviceCount; s++) {
+        const svc = servicePool[s];
+        const price = Math.round(isLuxuryRow ? randomPrice(80, 250) : randomPrice(20, 90));
+        await AppDataSource.query(
+          `INSERT INTO "Service" (
+            name, category, "serviceType", description, "priceType", price, duration, images, "businessId", "createdAt", "updatedAt"
+          ) VALUES ($1, $2, $3, $4, 'fixed', $5, $6, $7, $8, NOW(), NOW())`,
+          [
+            svc.name,
+            svc.category,
+            svc.type,
+            `${svc.name} at ${name}, ${city.city}.`,
+            price,
+            `${30 + (s % 3) * 15} mins`,
+            [businessImages[(created + s) % businessImages.length]],
+            businessId,
+          ],
+        );
+        servicesCreated++;
+      }
+
+      created++;
+      console.log(
+        `Created ${created}: ${name} — ${city.city}, ${city.state}, ${city.country} (rating ${rating}, ${isLuxuryRow ? 'LUXURY' : 'regular'}, ${serviceCount} services)`,
+      );
+    }
+  }
+
+  console.log('\n=== Seeding Complete ===');
+  console.log(`Created ${created} international salons (mix of luxury + non-luxury) across ${cityGroups.length} countries, all APPROVED.`);
+  console.log(`Created ${servicesCreated} bookable services across those salons.`);
+
+  await AppDataSource.destroy();
+}
+
+seed().catch((error) => {
+  console.error('Seeding failed:', error);
+  process.exit(1);
+});

--- a/scripts/seed-global-salons.ts
+++ b/scripts/seed-global-salons.ts
@@ -1,0 +1,252 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import * as dotenv from 'dotenv';
+import * as bcrypt from 'bcrypt';
+
+dotenv.config();
+
+// 50 international salons across 6 countries, spread over real
+// states/provinces/regions within each — KHS is a global platform and the
+// seed data was entirely Nigeria-only until now, which is why the location
+// filter only ever showed Nigerian cities. Addresses end in the CITY name
+// (matching the existing seed convention — getLocations() takes the last
+// comma-separated segment as the filterable location).
+
+const businessImages = [
+  'https://images.unsplash.com/photo-1560066984-138dadb4c035?w=800',
+  'https://images.unsplash.com/photo-1522337360788-8b13dee7a37e?w=800',
+  'https://images.unsplash.com/photo-1633681926022-84c23e8cb2d6?w=800',
+  'https://images.unsplash.com/photo-1521590832167-7bcbfaa6381f?w=800',
+  'https://images.unsplash.com/photo-1600948836101-f9ffda59d250?w=800',
+];
+
+const categories = ['hair-services', 'nail-services', 'spa-treatments', 'barbering', 'skincare'];
+const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+interface CityDef {
+  city: string;
+  state: string;
+  country: string;
+  lat: number;
+  lng: number;
+}
+
+// 10 per country/region group below, 6 groups = 60 city slots available;
+// we only use the first N per group as specified (AU 10, US 10, UK 8,
+// CA 8, UAE 6, ZA 8 = 50 total) — extra city defs beyond that per group
+// are simply unused, kept here for readability/spread within the group.
+const AU: CityDef[] = [
+  { city: 'Sydney', state: 'NSW', country: 'Australia', lat: -33.8688, lng: 151.2093 },
+  { city: 'Newcastle', state: 'NSW', country: 'Australia', lat: -32.9283, lng: 151.7817 },
+  { city: 'Melbourne', state: 'VIC', country: 'Australia', lat: -37.8136, lng: 144.9631 },
+  { city: 'Geelong', state: 'VIC', country: 'Australia', lat: -38.1499, lng: 144.3617 },
+  { city: 'Brisbane', state: 'QLD', country: 'Australia', lat: -27.4698, lng: 153.0251 },
+  { city: 'Gold Coast', state: 'QLD', country: 'Australia', lat: -28.0167, lng: 153.4 },
+  { city: 'Perth', state: 'WA', country: 'Australia', lat: -31.9505, lng: 115.8605 },
+  { city: 'Fremantle', state: 'WA', country: 'Australia', lat: -32.0569, lng: 115.7439 },
+  { city: 'Adelaide', state: 'SA', country: 'Australia', lat: -34.9285, lng: 138.6007 },
+  { city: 'Canberra', state: 'ACT', country: 'Australia', lat: -35.2809, lng: 149.13 },
+];
+
+const US: CityDef[] = [
+  { city: 'New York', state: 'NY', country: 'USA', lat: 40.7128, lng: -74.006 },
+  { city: 'Buffalo', state: 'NY', country: 'USA', lat: 42.8864, lng: -78.8784 },
+  { city: 'Los Angeles', state: 'CA', country: 'USA', lat: 34.0522, lng: -118.2437 },
+  { city: 'San Francisco', state: 'CA', country: 'USA', lat: 37.7749, lng: -122.4194 },
+  { city: 'Houston', state: 'TX', country: 'USA', lat: 29.7604, lng: -95.3698 },
+  { city: 'Austin', state: 'TX', country: 'USA', lat: 30.2672, lng: -97.7431 },
+  { city: 'Miami', state: 'FL', country: 'USA', lat: 25.7617, lng: -80.1918 },
+  { city: 'Orlando', state: 'FL', country: 'USA', lat: 28.5383, lng: -81.3792 },
+  { city: 'Atlanta', state: 'GA', country: 'USA', lat: 33.749, lng: -84.388 },
+  { city: 'Chicago', state: 'IL', country: 'USA', lat: 41.8781, lng: -87.6298 },
+];
+
+const UK: CityDef[] = [
+  { city: 'London', state: 'England', country: 'UK', lat: 51.5072, lng: -0.1276 },
+  { city: 'Manchester', state: 'England', country: 'UK', lat: 53.4808, lng: -2.2426 },
+  { city: 'Birmingham', state: 'England', country: 'UK', lat: 52.4862, lng: -1.8904 },
+  { city: 'Leeds', state: 'England', country: 'UK', lat: 53.8008, lng: -1.5491 },
+  { city: 'Bristol', state: 'England', country: 'UK', lat: 51.4545, lng: -2.5879 },
+  { city: 'Edinburgh', state: 'Scotland', country: 'UK', lat: 55.9533, lng: -3.1883 },
+  { city: 'Glasgow', state: 'Scotland', country: 'UK', lat: 55.8642, lng: -4.2518 },
+  { city: 'Cardiff', state: 'Wales', country: 'UK', lat: 51.4816, lng: -3.1791 },
+];
+
+const CA: CityDef[] = [
+  { city: 'Toronto', state: 'ON', country: 'Canada', lat: 43.6532, lng: -79.3832 },
+  { city: 'Ottawa', state: 'ON', country: 'Canada', lat: 45.4215, lng: -75.6972 },
+  { city: 'Vancouver', state: 'BC', country: 'Canada', lat: 49.2827, lng: -123.1207 },
+  { city: 'Victoria', state: 'BC', country: 'Canada', lat: 48.4284, lng: -123.3656 },
+  { city: 'Montreal', state: 'QC', country: 'Canada', lat: 45.5019, lng: -73.5674 },
+  { city: 'Quebec City', state: 'QC', country: 'Canada', lat: 46.8139, lng: -71.208 },
+  { city: 'Calgary', state: 'AB', country: 'Canada', lat: 51.0447, lng: -114.0719 },
+  { city: 'Edmonton', state: 'AB', country: 'Canada', lat: 53.5461, lng: -113.4938 },
+];
+
+const AE: CityDef[] = [
+  { city: 'Dubai', state: 'Dubai', country: 'UAE', lat: 25.2048, lng: 55.2708 },
+  { city: 'Abu Dhabi', state: 'Abu Dhabi', country: 'UAE', lat: 24.4539, lng: 54.3773 },
+  { city: 'Sharjah', state: 'Sharjah', country: 'UAE', lat: 25.3463, lng: 55.4209 },
+  { city: 'Al Ain', state: 'Abu Dhabi', country: 'UAE', lat: 24.2075, lng: 55.7447 },
+  { city: 'Ajman', state: 'Ajman', country: 'UAE', lat: 25.4052, lng: 55.5136 },
+  { city: 'Ras Al Khaimah', state: 'RAK', country: 'UAE', lat: 25.7895, lng: 55.9432 },
+];
+
+const ZA: CityDef[] = [
+  { city: 'Johannesburg', state: 'Gauteng', country: 'South Africa', lat: -26.2041, lng: 28.0473 },
+  { city: 'Pretoria', state: 'Gauteng', country: 'South Africa', lat: -25.7479, lng: 28.2293 },
+  { city: 'Cape Town', state: 'Western Cape', country: 'South Africa', lat: -33.9249, lng: 18.4241 },
+  { city: 'Stellenbosch', state: 'Western Cape', country: 'South Africa', lat: -33.9321, lng: 18.8602 },
+  { city: 'Durban', state: 'KwaZulu-Natal', country: 'South Africa', lat: -29.8587, lng: 31.0218 },
+  { city: 'Pietermaritzburg', state: 'KwaZulu-Natal', country: 'South Africa', lat: -29.6006, lng: 30.3794 },
+  { city: 'Port Elizabeth', state: 'Eastern Cape', country: 'South Africa', lat: -33.9608, lng: 25.6022 },
+  { city: 'Bloemfontein', state: 'Free State', country: 'South Africa', lat: -29.0852, lng: 26.1596 },
+];
+
+// Scaled down from the original 50 (10/10/8/8/6/8) to 18 total — the
+// larger batch, combined with a since-fixed N+1 query bug, made the salon
+// pages noticeably slow/unresponsive. Kept the same real state/city
+// variety per country, just fewer businesses per group.
+const cityGroups: { cities: CityDef[]; count: number }[] = [
+  { cities: AU, count: 3 },
+  { cities: US, count: 3 },
+  { cities: UK, count: 3 },
+  { cities: CA, count: 3 },
+  { cities: AE, count: 3 },
+  { cities: ZA, count: 3 },
+];
+
+const nameTemplates = [
+  'Radiant Hair Studio', 'The Braid House', 'Curl & Co.', 'Silk Strands Salon',
+  'Golden Comb Barbershop', 'Velvet Roots', 'The Glow Parlour', 'Twist & Shine',
+  'Crown Beauty Bar', 'Mane Attraction', 'The Loc Lounge', 'Polished Beauty Studio',
+  'Coco Curls', 'Sunset Salon & Spa', 'Elevate Hair Co.', 'The Style Foundry',
+  'Bare Beauty Bar', 'Prime Cuts Barbershop', 'Halo Hair Studio', 'The Vanity Room',
+  'Muse Salon', 'Onyx Hair Lounge', 'Radiance Beauty Studio', 'The Grooming Room',
+  'Aura Hair & Nails', 'Bloom & Blade', 'Kindred Beauty Co.', 'The Finishing Touch',
+  'Lush Locs Studio', 'Amber Beauty Bar', 'Nova Hair Studio', 'The Refined Edge',
+  'Willow Beauty Lounge', 'Ember & Co. Salon', 'Sage Beauty Studio', 'The Hair Atelier',
+  'Bliss Beauty Bar', 'Origin Barbershop', 'Flawless Beauty Studio', 'The Cut Above',
+  'Studio Noir', 'Rosewood Salon', 'Prestige Hair Studio', 'The Beauty Vault',
+  'Zenith Salon & Spa', 'Coastal Beauty Bar', 'Heritage Hair Studio', 'The Glow Room',
+  'Marble & Mane', 'Ivy Beauty Lounge',
+];
+
+const staffFirstNames = ['Alex', 'Jordan', 'Taylor', 'Morgan', 'Casey', 'Riley', 'Sam', 'Jamie', 'Drew', 'Skyler'];
+const staffLastNames = ['Smith', 'Johnson', 'Williams', 'Brown', 'Jones', 'Miller', 'Davis', 'Wilson', 'Taylor', 'Clark'];
+
+const AppDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DB_HOST ?? 'localhost',
+  port: parseInt(process.env.DB_PORT ?? '5432', 10),
+  username: process.env.DB_USERNAME ?? 'postgres',
+  password: process.env.DB_PASSWORD ?? 'password',
+  database: process.env.DB_DATABASE ?? 'kinky_hair_stylist',
+});
+
+async function seed() {
+  await AppDataSource.initialize();
+  console.log('Database connected');
+
+  const hashedPassword = await bcrypt.hash('password123', 10);
+  const nameList = nameTemplates.map((n) => `'${n.replace(/'/g, "''")}'`).join(',');
+
+  console.log('Cleaning up any prior run of this seed...');
+  try {
+    await AppDataSource.query(
+      `DELETE FROM booking_days WHERE "businessId" IN (SELECT id FROM businesses WHERE "businessName" IN (${nameList}))`,
+    );
+  } catch (e) {}
+  try {
+    await AppDataSource.query(`DELETE FROM businesses WHERE "businessName" IN (${nameList})`);
+  } catch (e) {}
+  try {
+    await AppDataSource.query(`DELETE FROM "user" WHERE email LIKE 'globalowner%@khs-global.local'`);
+  } catch (e) {}
+
+  let nameIdx = 0;
+  let created = 0;
+
+  for (const group of cityGroups) {
+    for (let i = 0; i < group.count; i++) {
+      const city = group.cities[i % group.cities.length];
+      const name = nameTemplates[nameIdx % nameTemplates.length];
+      nameIdx++;
+
+      const userResult = await AppDataSource.query(
+        `INSERT INTO "user" (
+          email, password, "firstName", surname, "phoneNumber",
+          "isVerified", "isClient", "isBusiness", "createdAt", "updatedAt"
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW()) RETURNING id`,
+        [
+          `globalowner${created + 1}@khs-global.local`,
+          hashedPassword,
+          staffFirstNames[created % staffFirstNames.length],
+          staffLastNames[created % staffLastNames.length],
+          `+1${String(1000000000 + created).padStart(10, '0')}`,
+          true,
+          true,
+          true,
+        ],
+      );
+      const ownerId = userResult[0].id;
+
+      const rating = +(3.6 + Math.random() * 1.4).toFixed(1); // 3.6 - 5.0, real spread including some 4.5+ (auto-luxury)
+
+      const businessResult = await AppDataSource.query(
+        `INSERT INTO businesses (
+          "businessName", description, "owner_id", "ownerName", "ownerEmail", "ownerPhone",
+          "primaryAudience", "businessAddress", "businessImage", longitude, latitude,
+          "companySize", status, category, plan, performance, revenue, bookings, "createdAt", "updatedAt"
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, 0, 0, NOW(), NOW()) RETURNING id`,
+        [
+          name,
+          `Welcome to ${name}! We offer premium beauty and grooming services in ${city.city}, ${city.state}.`,
+          ownerId,
+          `${staffFirstNames[created % staffFirstNames.length]} ${staffLastNames[created % staffLastNames.length]}`,
+          `globalowner${created + 1}@khs-global.local`,
+          `+1${String(1000000000 + created).padStart(10, '0')}`,
+          'Everyone looking for quality beauty services',
+          `${100 + created} High Street, ${city.state}, ${city.city}`,
+          JSON.stringify([
+            businessImages[created % businessImages.length],
+            businessImages[(created + 1) % businessImages.length],
+          ]),
+          city.lng + (Math.random() * 0.05 - 0.025),
+          city.lat + (Math.random() * 0.05 - 0.025),
+          'small-team',
+          'approved',
+          JSON.stringify([categories[created % categories.length], categories[(created + 1) % categories.length]]),
+          'Free',
+          JSON.stringify({
+            rating,
+            reviews: Math.floor(10 + Math.random() * 150),
+            completionRate: +(85 + Math.random() * 15).toFixed(0),
+            avgResponseMins: Math.floor(10 + Math.random() * 50),
+          }),
+        ],
+      );
+      const businessId = businessResult[0].id;
+
+      for (const day of days) {
+        await AppDataSource.query(
+          `INSERT INTO booking_days (day, "isOpen", "startTime", "endTime", "businessId") VALUES ($1, $2, $3, $4, $5)`,
+          [day, day !== 'Sunday', day === 'Saturday' ? '10:00' : '09:00', day === 'Saturday' ? '18:00' : '19:00', businessId],
+        );
+      }
+
+      created++;
+      console.log(`Created ${created}/50: ${name} — ${city.city}, ${city.state}, ${city.country} (rating ${rating})`);
+    }
+  }
+
+  console.log('\n=== Seeding Complete ===');
+  console.log(`Created ${created} international salons across ${cityGroups.length} countries, all APPROVED.`);
+
+  await AppDataSource.destroy();
+}
+
+seed().catch((error) => {
+  console.error('Seeding failed:', error);
+  process.exit(1);
+});

--- a/scripts/sync-schema.ts
+++ b/scripts/sync-schema.ts
@@ -21,7 +21,29 @@ async function main() {
   await AppDataSource.query(
     'ALTER TABLE "businesses" ADD COLUMN IF NOT EXISTS "revenueGoal" numeric(10,2) DEFAULT \'10000.00\';'
   );
-  
+
+  console.log('Altering appointments table to add business_client_id column...');
+  await AppDataSource.query(
+    'ALTER TABLE "appointments" ADD COLUMN IF NOT EXISTS "business_client_id" uuid;'
+  );
+  await AppDataSource.query(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'FK_appointments_business_client_id'
+      ) THEN
+        ALTER TABLE "appointments"
+          ADD CONSTRAINT "FK_appointments_business_client_id"
+          FOREIGN KEY ("business_client_id") REFERENCES "clients"("id") ON DELETE SET NULL;
+      END IF;
+    END $$;
+  `);
+
+  console.log('Altering appointments table to add clientConfirmedAt column...');
+  await AppDataSource.query(
+    'ALTER TABLE "appointments" ADD COLUMN IF NOT EXISTS "clientConfirmedAt" timestamptz;'
+  );
+
   console.log('Successfully altered table! Destroying connection...');
   await AppDataSource.destroy();
   console.log('Done!');

--- a/scripts/sync-stripe-schema.ts
+++ b/scripts/sync-stripe-schema.ts
@@ -1,0 +1,91 @@
+import { DataSource } from 'typeorm';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+const AppDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DB_HOST,
+  port: parseInt(process.env.DB_PORT ?? '5432', 10),
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_DATABASE,
+  ssl: process.env.DB_SSL === 'require' ? { rejectUnauthorized: false } : false,
+});
+
+async function main() {
+  console.log('Connecting to database for Stripe escrow schema sync...');
+  await AppDataSource.initialize();
+
+  console.log('Adding Stripe value to transactions_method_enum...');
+  // Postgres doesn't support IF NOT EXISTS on ADD VALUE before PG 12; this
+  // repo's target is modern Postgres (Neon), so the plain form is fine —
+  // wrap in a DO block to make it idempotent across re-runs regardless.
+  await AppDataSource.query(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_enum
+        WHERE enumlabel = 'Stripe'
+        AND enumtypid = 'transactions_method_enum'::regtype
+      ) THEN
+        ALTER TYPE transactions_method_enum ADD VALUE 'Stripe';
+      END IF;
+    END$$;
+  `);
+
+  console.log('Creating stripe_escrow_status_enum...');
+  await AppDataSource.query(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'stripe_payment_intents_status_enum') THEN
+        CREATE TYPE stripe_payment_intents_status_enum AS ENUM (
+          'pending', 'held', 'released', 'refunded', 'partially_refunded', 'failed', 'cancelled'
+        );
+      END IF;
+    END$$;
+  `);
+
+  console.log('Creating stripe_payment_intents table...');
+  await AppDataSource.query(`
+    CREATE TABLE IF NOT EXISTS stripe_payment_intents (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      "orderId" varchar(100) NOT NULL,
+      "businessId" uuid NOT NULL,
+      "userId" uuid NOT NULL,
+      "stripePaymentIntentId" varchar(255) NOT NULL,
+      "stripeChargeId" varchar(255),
+      amount numeric(12,2) NOT NULL,
+      currency varchar(3) NOT NULL DEFAULT 'usd',
+      "bookingAmount" numeric(12,2) NOT NULL,
+      "feeAmount" numeric(12,2) NOT NULL DEFAULT 0,
+      status stripe_payment_intents_status_enum NOT NULL DEFAULT 'pending',
+      "heldAt" timestamptz,
+      "releasedAt" timestamptz,
+      "refundedAt" timestamptz,
+      "transactionId" uuid,
+      "createdAt" timestamptz NOT NULL DEFAULT now(),
+      "updatedAt" timestamptz NOT NULL DEFAULT now()
+    );
+  `);
+
+  console.log('Adding indexes...');
+  await AppDataSource.query(`
+    CREATE INDEX IF NOT EXISTS "IDX_stripe_payment_intents_orderId" ON stripe_payment_intents ("orderId");
+  `);
+  await AppDataSource.query(`
+    CREATE INDEX IF NOT EXISTS "IDX_stripe_payment_intents_businessId" ON stripe_payment_intents ("businessId");
+  `);
+  await AppDataSource.query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS "IDX_stripe_payment_intents_stripePaymentIntentId" ON stripe_payment_intents ("stripePaymentIntentId");
+  `);
+
+  console.log('Schema sync complete. Destroying connection...');
+  await AppDataSource.destroy();
+  console.log('Done!');
+}
+
+main().catch((err) => {
+  console.error('Error during Stripe schema sync:', err);
+  process.exit(1);
+});

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -22,6 +22,9 @@ import { PaymentService } from './payment/payment.service';
 import { CloudinaryModule } from '../user/modules/cloudinary.module';
 import { BusinessWalletModule } from 'src/business/wallet.module';
 import { Transaction } from 'src/business/entities/transaction.entity';
+import { StripePaymentIntent } from 'src/payment/entities/stripe-payment-intent.entity';
+import { Refund } from 'src/user/user_entities/refund.entity';
+import { StripeService } from 'src/payment/stripe.service';
 
 @Module({
   imports: [
@@ -35,6 +38,8 @@ import { Transaction } from 'src/business/entities/transaction.entity';
     TypeOrmModule.forFeature([Payment]),
     TypeOrmModule.forFeature([Article]),
     TypeOrmModule.forFeature([Transaction]),
+    TypeOrmModule.forFeature([StripePaymentIntent]),
+    TypeOrmModule.forFeature([Refund]),
     CloudinaryModule,
     BusinessWalletModule,
     EmailModule,
@@ -43,6 +48,7 @@ import { Transaction } from 'src/business/entities/transaction.entity';
   providers: [
     AdminService,
     PaymentService,
+    StripeService,
     ArticleService,
     AdminAuthService,
     AdminAuthStrategy,

--- a/src/admin/payment/payment.controller.ts
+++ b/src/admin/payment/payment.controller.ts
@@ -133,6 +133,29 @@ export class PaymentController {
     return this.paymentService.getDisputes();
   }
 
+  // Manual support override — releases Stripe escrow to the business wallet
+  // without waiting for the automatic completion trigger.
+  @ApiBearerAuth('access-token')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.Admin, Role.SuperAdmin)
+  @Patch('stripe/:orderId/release')
+  releaseStripeEscrow(@Param('orderId') orderId: string) {
+    return this.paymentService.releaseStripeEscrow(orderId);
+  }
+
+  // Manual support override — refunds Stripe escrow outside the normal
+  // booking-cancellation flow.
+  @ApiBearerAuth('access-token')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.Admin, Role.SuperAdmin)
+  @Post('stripe/:orderId/refund')
+  refundStripeEscrow(
+    @Param('orderId') orderId: string,
+    @Body('reason') reason?: string,
+  ) {
+    return this.paymentService.refundStripeEscrow(orderId, reason);
+  }
+
   @ApiBearerAuth('access-token')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.Admin, Role.SuperAdmin, Role.Client)

--- a/src/admin/payment/payment.module.ts
+++ b/src/admin/payment/payment.module.ts
@@ -6,14 +6,25 @@ import { PaymentController } from './payment.controller';
 import { Business } from 'src/business/entities/business.entity';
 import { BusinessWalletModule } from 'src/business/wallet.module';
 import { Transaction } from 'src/business/entities/transaction.entity';
+import { StripePaymentIntent } from 'src/payment/entities/stripe-payment-intent.entity';
+import { Appointment } from 'src/business/entities/appointment.entity';
+import { Refund } from 'src/user/user_entities/refund.entity';
+import { StripeService } from 'src/payment/stripe.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Payment, Business, Transaction]),
+    TypeOrmModule.forFeature([
+      Payment,
+      Business,
+      Transaction,
+      StripePaymentIntent,
+      Appointment,
+      Refund,
+    ]),
     BusinessWalletModule,
   ],
   controllers: [PaymentController],
-  providers: [PaymentService],
+  providers: [PaymentService, StripeService],
   exports: [PaymentService],
 })
 export class PaymentModule {}

--- a/src/admin/payment/payment.service.ts
+++ b/src/admin/payment/payment.service.ts
@@ -394,6 +394,28 @@ export class PaymentService {
 
   // Manually refund Stripe escrow for a booking — support override for
   // cases needing a refund outside the normal cancellation flow.
+  // Refund policy: the customer gets back the service amount minus KHS's
+  // own platform fee minus Stripe's real processing fee for that specific
+  // charge (looked up from Stripe, not estimated). 0 or negative means
+  // nothing is left to refund after those deductions.
+  private async calculateStripeRefundAmountCents(
+    spi: StripePaymentIntent,
+  ): Promise<number> {
+    if (!spi.stripeChargeId) {
+      throw new BadRequestException(
+        `Stripe charge ID missing for payment intent ${spi.stripePaymentIntentId} — cannot compute refund`,
+      );
+    }
+
+    const stripeFeeCents = await this.stripeService.getChargeFee(
+      spi.stripeChargeId,
+    );
+    const bookingAmountCents = Math.round(spi.bookingAmount * 100);
+    const platformFeeCents = Math.round(spi.feeAmount * 100);
+
+    return bookingAmountCents - platformFeeCents - stripeFeeCents;
+  }
+
   async refundStripeEscrow(orderId: string, reason?: string) {
     const heldPaymentIntents = await this.stripePaymentIntentRepo.find({
       where: { orderId, status: StripeEscrowStatus.HELD },
@@ -405,10 +427,24 @@ export class PaymentService {
       );
     }
 
-    const refunded: string[] = [];
+    // Pre-flight: compute every refund amount before refunding anything,
+    // so a blocked one doesn't leave the order in a half-refunded state.
+    const refundPlans: { spi: StripePaymentIntent; refundAmountCents: number }[] = [];
     for (const spi of heldPaymentIntents) {
+      const refundAmountCents = await this.calculateStripeRefundAmountCents(spi);
+      if (refundAmountCents <= 0) {
+        throw new BadRequestException(
+          `Cannot refund: after deducting the platform fee and Stripe's processing fee, no refundable amount remains for order ${orderId}.`,
+        );
+      }
+      refundPlans.push({ spi, refundAmountCents });
+    }
+
+    const refunded: string[] = [];
+    for (const { spi, refundAmountCents } of refundPlans) {
       const stripeRefund = await this.stripeService.createRefund({
         paymentIntentId: spi.stripePaymentIntentId,
+        amount: refundAmountCents,
       });
 
       spi.status = StripeEscrowStatus.REFUNDED;
@@ -428,10 +464,10 @@ export class PaymentService {
           this.refundRepo.create({
             transactionId: debitTx.id,
             userId: spi.userId,
-            amount: spi.amount,
+            amount: refundAmountCents / 100,
             currency: spi.currency.toUpperCase(),
             reason: reason || 'Admin-initiated refund',
-            adminNote: `Stripe refund ${stripeRefund.id}`,
+            adminNote: `Stripe refund ${stripeRefund.id} (platform fee + Stripe processing fee withheld)`,
             status: RefundStatus.PROCESSED,
             refundMethod: RefundMethod.CARD_REFUND,
           }),

--- a/src/admin/payment/payment.service.ts
+++ b/src/admin/payment/payment.service.ts
@@ -23,6 +23,17 @@ import {
   TransactionType,
 } from 'src/business/entities/transaction.entity';
 import { WalletCurrency } from './enums/wallet.enum';
+import {
+  StripePaymentIntent,
+  StripeEscrowStatus,
+} from 'src/payment/entities/stripe-payment-intent.entity';
+import { StripeService } from 'src/payment/stripe.service';
+import { Appointment } from 'src/business/entities/appointment.entity';
+import {
+  Refund,
+  RefundStatus,
+  RefundMethod,
+} from 'src/user/user_entities/refund.entity';
 
 @Injectable()
 export class PaymentService {
@@ -38,7 +49,14 @@ export class PaymentService {
     private readonly businessRepo: Repository<Business>,
     @InjectRepository(Transaction)
     private readonly transactionRepo: Repository<Transaction>,
+    @InjectRepository(StripePaymentIntent)
+    private readonly stripePaymentIntentRepo: Repository<StripePaymentIntent>,
+    @InjectRepository(Appointment)
+    private readonly appointmentRepo: Repository<Appointment>,
+    @InjectRepository(Refund)
+    private readonly refundRepo: Repository<Refund>,
     private readonly businessWalletService: BusinessWalletService,
+    private readonly stripeService: StripeService,
   ) {
     this.frontendUrl = process.env.FRONTEND_URL ?? '';
     this.paystackAcessKey = process.env.PAYSTACK_SECRET_KEY!;
@@ -309,6 +327,121 @@ export class PaymentService {
 
   async getDisputes() {
     return this.paymentRepo.find({ where: { status: 'disputed' } });
+  }
+
+  // Manually release Stripe escrow for a booking — support override for
+  // cases where the automatic completion trigger
+  // (BusinessService.completeBooking) didn't fire or needs correcting.
+  async releaseStripeEscrow(orderId: string) {
+    const heldPaymentIntents = await this.stripePaymentIntentRepo.find({
+      where: { orderId, status: StripeEscrowStatus.HELD },
+    });
+
+    if (heldPaymentIntents.length === 0) {
+      throw new NotFoundException(
+        `No held Stripe escrow found for order ${orderId}`,
+      );
+    }
+
+    const appointment = await this.appointmentRepo.findOne({
+      where: { orderId },
+      relations: ['business', 'business.owner'],
+    });
+    if (!appointment) {
+      throw new NotFoundException(`No appointment found for order ${orderId}`);
+    }
+
+    const businessId = appointment.business.id;
+    const ownerId = appointment.business.owner?.id;
+    if (!businessId || !ownerId) {
+      throw new BadRequestException('Business or owner not found for this booking');
+    }
+
+    const released: string[] = [];
+    for (const spi of heldPaymentIntents) {
+      try {
+        await this.businessWalletService.getWalletByBusinessId(businessId);
+      } catch {
+        await this.businessWalletService.createWalletForBusiness({
+          businessId,
+          ownerId,
+          currency: WalletCurrency.USD,
+          description: 'Business wallet - auto-created from booking',
+        });
+      }
+
+      await this.businessWalletService.addFunds({
+        businessId,
+        recipientId: ownerId,
+        senderId: spi.userId,
+        amount: spi.bookingAmount,
+        type: TransactionType.EARNING,
+        description: `Manual escrow release for order ${orderId}`,
+        referenceId: spi.stripePaymentIntentId,
+        currency: WalletCurrency.USD,
+        mode: 'Web',
+        method: PaymentMethod.STRIPE,
+      });
+
+      spi.status = StripeEscrowStatus.RELEASED;
+      spi.releasedAt = new Date();
+      await this.stripePaymentIntentRepo.save(spi);
+      released.push(spi.stripePaymentIntentId);
+    }
+
+    return { message: 'Escrow released successfully', released };
+  }
+
+  // Manually refund Stripe escrow for a booking — support override for
+  // cases needing a refund outside the normal cancellation flow.
+  async refundStripeEscrow(orderId: string, reason?: string) {
+    const heldPaymentIntents = await this.stripePaymentIntentRepo.find({
+      where: { orderId, status: StripeEscrowStatus.HELD },
+    });
+
+    if (heldPaymentIntents.length === 0) {
+      throw new NotFoundException(
+        `No held Stripe escrow found for order ${orderId}`,
+      );
+    }
+
+    const refunded: string[] = [];
+    for (const spi of heldPaymentIntents) {
+      const stripeRefund = await this.stripeService.createRefund({
+        paymentIntentId: spi.stripePaymentIntentId,
+      });
+
+      spi.status = StripeEscrowStatus.REFUNDED;
+      spi.refundedAt = new Date();
+      await this.stripePaymentIntentRepo.save(spi);
+
+      const debitTx = await this.transactionRepo.findOne({
+        where: {
+          referenceId: spi.stripePaymentIntentId,
+          service: 'Booking',
+          method: PaymentMethod.STRIPE,
+        },
+      });
+
+      if (debitTx) {
+        await this.refundRepo.save(
+          this.refundRepo.create({
+            transactionId: debitTx.id,
+            userId: spi.userId,
+            amount: spi.amount,
+            currency: spi.currency.toUpperCase(),
+            reason: reason || 'Admin-initiated refund',
+            adminNote: `Stripe refund ${stripeRefund.id}`,
+            status: RefundStatus.PROCESSED,
+            refundMethod: RefundMethod.CARD_REFUND,
+          }),
+        );
+      }
+
+      refunded.push(spi.stripePaymentIntentId);
+    }
+
+    return { message: 'Escrow refunded successfully', refunded };
   }
 
   async deleteAllPayments() {

--- a/src/business/business.module.ts
+++ b/src/business/business.module.ts
@@ -29,6 +29,7 @@ import { GoogleCalendarModule } from 'src/integration/google-calendar.module';
 import { MailchimpModule } from 'src/integration/mail-chimp.module';
 import { BusinessOwnerSettingsModule } from './business-owner-settings.module';
 import { ZohoBooksModule } from 'src/integration/zohobooks.module';
+import { StripePaymentIntent } from 'src/payment/entities/stripe-payment-intent.entity';
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { ZohoBooksModule } from 'src/integration/zohobooks.module';
       Service,
       EmergencyContact,
       ClientSchema,
+      StripePaymentIntent,
     ]),
     JwtModule.register({}),
     EmailModule,

--- a/src/business/entities/appointment.entity.ts
+++ b/src/business/entities/appointment.entity.ts
@@ -106,6 +106,11 @@ export class Appointment {
   })
   paymentStatus: PaymentStatus;
 
+  // Client confirming their own intent to attend (distinct from the
+  // salon-side AppointmentStatus.CONFIRMED, which the merchant sets).
+  @Column({ type: 'timestamptz', nullable: true })
+  clientConfirmedAt?: Date;
+
   // Optional Notes
   @Column({ type: 'text', nullable: true })
   specialRequests?: string;

--- a/src/business/entities/appointment.entity.ts
+++ b/src/business/entities/appointment.entity.ts
@@ -118,6 +118,22 @@ export class Appointment {
   @Column({ type: 'text', nullable: true })
   cancellationsNote?: string;
 
+  // When this appointment was cancelled — separate from updatedAt, which
+  // changes on every unrelated edit (reschedule, restore, staff change).
+  // Needed to sort/list cancelled bookings by actual cancellation recency.
+  @Column({ type: 'timestamptz', nullable: true })
+  cancelledAt?: Date;
+
+  // Staged new date/time for a Rebook of a Cancelled appointment. Kept
+  // separate from date/time so an abandoned rebook (never paid) leaves the
+  // original cancelled booking completely untouched — these are only
+  // promoted into date/time once payment actually succeeds.
+  @Column({ type: 'varchar', nullable: true })
+  pendingRebookDate?: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  pendingRebookTime?: string;
+
   // Appointment timeline
   @Column({
     type: 'jsonb',

--- a/src/business/entities/transaction.entity.ts
+++ b/src/business/entities/transaction.entity.ts
@@ -31,6 +31,7 @@ export enum PaymentMethod {
   PAYPAL = 'PayPal',
   GIFTCARD = 'GiftCard',
   CASH = 'Cash',
+  STRIPE = 'Stripe',
 }
 
 export enum TransactionStatus {

--- a/src/business/services/business.service.ts
+++ b/src/business/services/business.service.ts
@@ -6,6 +6,14 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Admin, In, Not, Repository } from 'typeorm';
+import {
+  TransactionType,
+  PaymentMethod,
+} from '../entities/transaction.entity';
+import {
+  StripePaymentIntent,
+  StripeEscrowStatus,
+} from 'src/payment/entities/stripe-payment-intent.entity';
 import { Business } from '../entities/business.entity';
 import { User } from '../../all_user_entities/user.entity';
 import { CreateBusinessDto } from '../dtos/requests/CreateBusinessDto';
@@ -46,7 +54,11 @@ import { promises } from 'dns';
 
 @Injectable()
 export class BusinessService {
+  private readonly logger = new Logger(BusinessService.name);
+
   constructor(
+    @InjectRepository(StripePaymentIntent)
+    private readonly stripePaymentIntentRepo: Repository<StripePaymentIntent>,
     @InjectRepository(BookingDay)
     private readonly bookingDayRepo: Repository<BookingDay>,
 
@@ -162,6 +174,59 @@ export class BusinessService {
     appointment.status = AppointmentStatus.COMPLETED;
 
     await this.appointmentRepo.save(appointment);
+
+    // Release any Stripe escrow held for this booking now that the
+    // appointment is done — a no-op for Paystack/gift-card/cash bookings,
+    // which have no StripePaymentIntent row at all.
+    try {
+      const heldPaymentIntents = await this.stripePaymentIntentRepo.find({
+        where: {
+          orderId: appointment.orderId,
+          status: StripeEscrowStatus.HELD,
+        },
+      });
+
+      for (const spi of heldPaymentIntents) {
+        const businessId = appointment.business.id;
+        const ownerId = appointment.business.owner?.id;
+        if (!businessId || !ownerId) continue;
+
+        try {
+          await this.walletService.getWalletByBusinessId(businessId);
+        } catch {
+          await this.walletService.createWalletForBusiness({
+            businessId,
+            ownerId,
+            currency: WalletCurrency.USD,
+            description: 'Business wallet - auto-created from booking',
+          });
+        }
+
+        await this.walletService.addFunds({
+          businessId,
+          recipientId: ownerId,
+          senderId: spi.userId,
+          amount: spi.bookingAmount,
+          type: TransactionType.EARNING,
+          description: `Escrow release for completed booking ${appointment.orderId}`,
+          referenceId: spi.stripePaymentIntentId,
+          currency: WalletCurrency.USD,
+          mode: 'Web',
+          method: PaymentMethod.STRIPE,
+        });
+
+        spi.status = StripeEscrowStatus.RELEASED;
+        spi.releasedAt = new Date();
+        await this.stripePaymentIntentRepo.save(spi);
+      }
+    } catch (escrowError) {
+      // This moves real customer money out of escrow — log loudly, but
+      // completing the appointment must still succeed even if this fails.
+      this.logger.error(
+        `Failed to release Stripe escrow for order ${appointment.orderId}: ${escrowError.message}`,
+        escrowError.stack,
+      );
+    }
 
     const settings = await this.businessOwnerSettingsService.findByBusinessId(
       appointment.business.id,

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,10 @@ async function bootstrap() {
   // to support bracket-notation array params like services[]=x
   app.getHttpAdapter().getInstance().set('query parser', 'extended');
 
+  // Stripe webhook signature verification needs the exact raw request bytes,
+  // which the global JSON parser below would otherwise consume — capture
+  // the raw body only for this one path before JSON parsing runs.
+  app.use('/api/webhook/stripe', express.raw({ type: 'application/json' }));
   app.use(express.json({ limit: '10mb' }));
   app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,9 +68,16 @@ async function bootstrap() {
     }),
   );
 
-  // Input sanitization setup
+  // Input sanitization setup — skipped for the Stripe webhook path, whose
+  // body must stay an untouched raw Buffer for signature verification
+  // (see the express.raw() registration above). Webhook payloads are
+  // trusted via that cryptographic signature, not sanitized like
+  // user-typed input.
   const sanitizer = new InputSanitizationMiddleware();
-  app.use((req, res, next) => sanitizer.use(req, res, next));
+  app.use((req, res, next) => {
+    if (req.path === '/api/webhook/stripe') return next();
+    sanitizer.use(req, res, next);
+  });
 
   // Session Configuration
   app.use(

--- a/src/payment/entities/stripe-payment-intent.entity.ts
+++ b/src/payment/entities/stripe-payment-intent.entity.ts
@@ -1,0 +1,87 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum StripeEscrowStatus {
+  PENDING = 'pending',
+  HELD = 'held',
+  RELEASED = 'released',
+  REFUNDED = 'refunded',
+  PARTIALLY_REFUNDED = 'partially_refunded',
+  FAILED = 'failed',
+  CANCELLED = 'cancelled',
+}
+
+// Tracks the escrow lifecycle of a single Stripe PaymentIntent for a
+// booking: funds are captured by Stripe/KHS at HELD, but only credited to
+// the business wallet (RELEASED) once the appointment is marked Completed
+// — unlike the existing Paystack flow, which credits the wallet the moment
+// payment clears. See BookingService.confirmBooking's 'stripe' branch and
+// BusinessService.completeBooking's release hook.
+@Entity('stripe_payment_intents')
+export class StripePaymentIntent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column({ type: 'varchar', length: 100 })
+  orderId: string;
+
+  @Index()
+  @Column({ type: 'uuid' })
+  businessId: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Index({ unique: true })
+  @Column({ type: 'varchar', length: 255 })
+  stripePaymentIntentId: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  stripeChargeId: string;
+
+  @Column({ type: 'decimal', precision: 12, scale: 2 })
+  amount: number;
+
+  @Column({ type: 'varchar', length: 3, default: 'usd' })
+  currency: string;
+
+  // Service amount only — excludes feeAmount, matching how the business
+  // wallet is credited on release (fee stays platform revenue).
+  @Column({ type: 'decimal', precision: 12, scale: 2 })
+  bookingAmount: number;
+
+  @Column({ type: 'decimal', precision: 12, scale: 2, default: 0 })
+  feeAmount: number;
+
+  @Column({
+    type: 'enum',
+    enum: StripeEscrowStatus,
+    default: StripeEscrowStatus.PENDING,
+  })
+  status: StripeEscrowStatus;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  heldAt: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  releasedAt: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  refundedAt: Date;
+
+  @Column({ type: 'uuid', nullable: true })
+  transactionId: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/payment/stripe.service.ts
+++ b/src/payment/stripe.service.ts
@@ -73,6 +73,28 @@ export class StripeService {
     }
   }
 
+  /**
+   * Returns the exact fee Stripe kept from a charge (in cents), via the
+   * charge's balance_transaction. Not a fixed/estimated rate — the real
+   * amount, which varies slightly by card type/country.
+   */
+  async getChargeFee(chargeId: string): Promise<number> {
+    try {
+      const charge = await this.stripe.charges.retrieve(chargeId, {
+        expand: ['balance_transaction'],
+      });
+      const balanceTransaction = charge.balance_transaction;
+      if (!balanceTransaction || typeof balanceTransaction === 'string') {
+        throw new Error('balance_transaction was not expanded');
+      }
+      return balanceTransaction.fee;
+    } catch (error) {
+      throw new BadRequestException(
+        `Unable to retrieve Stripe charge fee: ${error.message}`,
+      );
+    }
+  }
+
   /** Verifies and parses a webhook payload — requires the raw request body, not parsed JSON */
   constructWebhookEvent(rawBody: Buffer, signature: string): Stripe.Event {
     if (!this.webhookSecret) {

--- a/src/payment/stripe.service.ts
+++ b/src/payment/stripe.service.ts
@@ -1,0 +1,87 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import Stripe from 'stripe';
+
+@Injectable()
+export class StripeService {
+  private readonly secretKey = process.env.STRIPE_SECRET_KEY;
+  private readonly webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  private readonly stripe: Stripe;
+
+  constructor() {
+    if (!this.secretKey) {
+      throw new Error('STRIPE_SECRET_KEY must be set');
+    }
+    this.stripe = new Stripe(this.secretKey);
+  }
+
+  /** Create a PaymentIntent — the customer confirms it client-side via Stripe Elements */
+  async createPaymentIntent(payload: {
+    amount: number; // in the smallest currency unit (cents)
+    currency: string;
+    customerEmail: string;
+    metadata: Record<string, string | number>;
+  }): Promise<Stripe.PaymentIntent> {
+    if (!payload.amount || payload.amount <= 0) {
+      throw new BadRequestException('Amount must be greater than 0');
+    }
+    if (!Number.isInteger(payload.amount)) {
+      throw new BadRequestException('Amount must be an integer (in cents)');
+    }
+
+    try {
+      return await this.stripe.paymentIntents.create({
+        amount: payload.amount,
+        currency: payload.currency,
+        receipt_email: payload.customerEmail,
+        metadata: payload.metadata as Record<string, string>,
+        automatic_payment_methods: { enabled: true },
+      });
+    } catch (error) {
+      throw new BadRequestException(
+        `Unable to create Stripe payment intent: ${error.message}`,
+      );
+    }
+  }
+
+  async retrievePaymentIntent(
+    paymentIntentId: string,
+  ): Promise<Stripe.PaymentIntent> {
+    try {
+      return await this.stripe.paymentIntents.retrieve(paymentIntentId);
+    } catch (error) {
+      throw new BadRequestException(
+        `Unable to retrieve Stripe payment intent: ${error.message}`,
+      );
+    }
+  }
+
+  async createRefund(payload: {
+    paymentIntentId: string;
+    amount?: number; // omit to refund in full
+    reason?: Stripe.RefundCreateParams.Reason;
+  }): Promise<Stripe.Refund> {
+    try {
+      return await this.stripe.refunds.create({
+        payment_intent: payload.paymentIntentId,
+        amount: payload.amount,
+        reason: payload.reason,
+      });
+    } catch (error) {
+      throw new BadRequestException(
+        `Unable to create Stripe refund: ${error.message}`,
+      );
+    }
+  }
+
+  /** Verifies and parses a webhook payload — requires the raw request body, not parsed JSON */
+  constructWebhookEvent(rawBody: Buffer, signature: string): Stripe.Event {
+    if (!this.webhookSecret) {
+      throw new Error('STRIPE_WEBHOOK_SECRET must be set');
+    }
+    return this.stripe.webhooks.constructEvent(
+      rawBody,
+      signature,
+      this.webhookSecret,
+    );
+  }
+}

--- a/src/payment/stripe.service.ts
+++ b/src/payment/stripe.service.ts
@@ -79,20 +79,38 @@ export class StripeService {
    * amount, which varies slightly by card type/country.
    */
   async getChargeFee(chargeId: string): Promise<number> {
-    try {
-      const charge = await this.stripe.charges.retrieve(chargeId, {
-        expand: ['balance_transaction'],
-      });
-      const balanceTransaction = charge.balance_transaction;
-      if (!balanceTransaction || typeof balanceTransaction === 'string') {
-        throw new Error('balance_transaction was not expanded');
+    // Stripe attaches balance_transaction to a charge asynchronously,
+    // shortly after the charge succeeds — cancelling/refunding right after
+    // payment can land here before it's ready. Retry with backoff instead
+    // of failing immediately, since this resolves itself within seconds.
+    const maxAttempts = 3;
+    const delayMs = 800;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const charge = await this.stripe.charges.retrieve(chargeId, {
+          expand: ['balance_transaction'],
+        });
+        const balanceTransaction = charge.balance_transaction;
+        if (balanceTransaction && typeof balanceTransaction !== 'string') {
+          return balanceTransaction.fee;
+        }
+      } catch (error) {
+        if (attempt === maxAttempts) {
+          throw new BadRequestException(
+            `Unable to retrieve Stripe charge fee: ${error.message}`,
+          );
+        }
       }
-      return balanceTransaction.fee;
-    } catch (error) {
-      throw new BadRequestException(
-        `Unable to retrieve Stripe charge fee: ${error.message}`,
-      );
+
+      if (attempt < maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
     }
+
+    throw new BadRequestException(
+      'Unable to retrieve Stripe charge fee: balance_transaction was not expanded',
+    );
   }
 
   /** Verifies and parses a webhook payload — requires the raw request body, not parsed JSON */

--- a/src/user/controllers/booking.controller.ts
+++ b/src/user/controllers/booking.controller.ts
@@ -106,6 +106,14 @@ export class BookingController {
     return this.bookingService.restoreBooking(orderId);
   }
 
+  // Client confirms their own intent to attend
+  @Patch(':orderId/confirm-availability')
+  @ApiOperation({ summary: "Client confirms they'll be attending this appointment" })
+  @ApiResponse({ status: 200, description: 'Availability confirmed' })
+  async confirmAvailability(@Param('orderId') orderId: string, @GetUser() user: User) {
+    return this.bookingService.confirmAvailability(orderId, user);
+  }
+
   // Rate booking business
   @Post(':orderId/rate')
   @ApiOperation({ summary: 'Rate a business for a specific booking' })

--- a/src/user/dtos/confirm-booking.dto.ts
+++ b/src/user/dtos/confirm-booking.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class ConfirmBookingDto {
   @ApiProperty({
@@ -9,6 +9,16 @@ export class ConfirmBookingDto {
   @IsString()
   @IsNotEmpty()
   orderId: string;
+
+  @ApiProperty({
+    example: 'paystack',
+    description: 'Which payment provider to use for the card portion (defaults to paystack)',
+    enum: ['paystack', 'stripe'],
+    required: false,
+  })
+  @IsOptional()
+  @IsIn(['paystack', 'stripe'])
+  paymentProvider?: 'paystack' | 'stripe';
 
   @ApiProperty({
     example: true,

--- a/src/user/modules/booking.module.ts
+++ b/src/user/modules/booking.module.ts
@@ -19,11 +19,12 @@ import { Card } from 'src/all_user_entities/card.entity';
 import { PaystackService } from 'src/payment/paystack.service';
 import { StripeService } from 'src/payment/stripe.service';
 import { StripePaymentIntent } from 'src/payment/entities/stripe-payment-intent.entity';
+import { Refund } from 'src/user/user_entities/refund.entity';
 import { NotificationSettingsModule } from './notification-settings.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Appointment, Business, Service, Staff, Transaction, BusinessGiftCard, PlatformSettingsEntity, Review, ClientSchema, Card, StripePaymentIntent]),
+    TypeOrmModule.forFeature([Appointment, Business, Service, Staff, Transaction, BusinessGiftCard, PlatformSettingsEntity, Review, ClientSchema, Card, StripePaymentIntent, Refund]),
     ReviewModule,
     BusinessWalletModule,
     EmailModule,

--- a/src/user/modules/booking.module.ts
+++ b/src/user/modules/booking.module.ts
@@ -17,17 +17,20 @@ import { Review } from 'src/business/entities/review.entity';
 import { ClientSchema } from 'src/business/entities/client.entity';
 import { Card } from 'src/all_user_entities/card.entity';
 import { PaystackService } from 'src/payment/paystack.service';
+import { StripeService } from 'src/payment/stripe.service';
+import { StripePaymentIntent } from 'src/payment/entities/stripe-payment-intent.entity';
 import { NotificationSettingsModule } from './notification-settings.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Appointment, Business, Service, Staff, Transaction, BusinessGiftCard, PlatformSettingsEntity, Review, ClientSchema, Card]),
+    TypeOrmModule.forFeature([Appointment, Business, Service, Staff, Transaction, BusinessGiftCard, PlatformSettingsEntity, Review, ClientSchema, Card, StripePaymentIntent]),
     ReviewModule,
     BusinessWalletModule,
     EmailModule,
     NotificationSettingsModule,
   ],
   controllers: [BookingController],
-  providers: [BookingService, PlatformSettingsService, PaystackService],
+  providers: [BookingService, PlatformSettingsService, PaystackService, StripeService],
+  exports: [BookingService],
 })
 export class BookingModule {}

--- a/src/user/services/booking.service.ts
+++ b/src/user/services/booking.service.ts
@@ -899,6 +899,28 @@ export class BookingService {
     return { message: 'Appointment restored successfully' };
   }
 
+  // Client confirms their own intent to attend
+  async confirmAvailability(
+    orderId: string,
+    user: User,
+  ): Promise<{ message: string; clientConfirmedAt: Date }> {
+    const appointments = await this.bookingRepository.find({
+      where: { orderId, client: { id: user.id } },
+    });
+
+    if (appointments.length === 0) {
+      throw new NotFoundException('No appointments found for this order ID');
+    }
+
+    const clientConfirmedAt = new Date();
+    for (const appointment of appointments) {
+      appointment.clientConfirmedAt = clientConfirmedAt;
+    }
+    await this.bookingRepository.save(appointments);
+
+    return { message: 'Availability confirmed', clientConfirmedAt };
+  }
+
   // Reschedule Booking
   async rescheduleBooking(
     orderId: string,

--- a/src/user/services/booking.service.ts
+++ b/src/user/services/booking.service.ts
@@ -31,6 +31,11 @@ import {
   StripePaymentIntent,
   StripeEscrowStatus,
 } from 'src/payment/entities/stripe-payment-intent.entity';
+import {
+  Refund,
+  RefundStatus,
+  RefundMethod,
+} from 'src/user/user_entities/refund.entity';
 import { Card } from 'src/all_user_entities/card.entity';
 import { BusinessGiftCard } from 'src/business/entities/business-giftcard.entity';
 import { BusinessGiftCardStatus } from 'src/business/enum/gift-card.enum';
@@ -62,6 +67,8 @@ export class BookingService {
     private cardRepository: Repository<Card>,
     @InjectRepository(StripePaymentIntent)
     private stripePaymentIntentRepository: Repository<StripePaymentIntent>,
+    @InjectRepository(Refund)
+    private refundRepository: Repository<Refund>,
     private platformSettingsService: PlatformSettingsService,
     private reviewService: ReviewService,
     private readonly dataSource: DataSource,
@@ -1032,6 +1039,55 @@ export class BookingService {
     }
 
     await this.bookingRepository.save(appointmentsToCancel);
+
+    // Refund any Stripe escrow held for this booking — a no-op for
+    // Paystack/gift-card/cash appointments, which have no
+    // StripePaymentIntent row. Nothing was ever credited to the wallet at
+    // HELD time, so unlike Paystack there's no wallet balance to reverse
+    // here — only the Stripe-side charge itself needs refunding.
+    try {
+      const heldPaymentIntents = await this.stripePaymentIntentRepository.find({
+        where: { orderId, status: StripeEscrowStatus.HELD },
+      });
+
+      for (const spi of heldPaymentIntents) {
+        const stripeRefund = await this.stripeService.createRefund({
+          paymentIntentId: spi.stripePaymentIntentId,
+        });
+
+        spi.status = StripeEscrowStatus.REFUNDED;
+        spi.refundedAt = new Date();
+        await this.stripePaymentIntentRepository.save(spi);
+
+        const debitTx = await this.transactionRepository.findOne({
+          where: {
+            referenceId: spi.stripePaymentIntentId,
+            service: 'Booking',
+            method: PaymentMethod.STRIPE,
+          },
+        });
+
+        if (debitTx) {
+          await this.refundRepository.save(
+            this.refundRepository.create({
+              transactionId: debitTx.id,
+              userId: spi.userId,
+              amount: spi.amount,
+              currency: spi.currency.toUpperCase(),
+              reason: cancellationsNote || 'Booking cancelled before completion',
+              adminNote: `Stripe refund ${stripeRefund.id}`,
+              status: RefundStatus.PROCESSED,
+              refundMethod: RefundMethod.CARD_REFUND,
+            }),
+          );
+        }
+      }
+    } catch (refundError) {
+      this.logger.error(
+        `Failed to refund Stripe escrow for order ${orderId}: ${refundError.message}`,
+        refundError.stack,
+      );
+    }
 
     const firstAppt = appointmentsToCancel[0];
     if (firstAppt?.client?.email) {

--- a/src/user/services/booking.service.ts
+++ b/src/user/services/booking.service.ts
@@ -140,6 +140,18 @@ export class BookingService {
     return { orderId, appointments };
   }
 
+  // Promotes a staged Rebook date/time onto the real date/time fields and
+  // clears the staging columns. Called only at the point payment actually
+  // succeeds — mutates in place, caller is responsible for saving.
+  private applyPendingRebookDate(appointment: Appointment): void {
+    if (appointment.pendingRebookDate && appointment.pendingRebookTime) {
+      appointment.date = appointment.pendingRebookDate;
+      appointment.time = appointment.pendingRebookTime;
+      appointment.pendingRebookDate = undefined;
+      appointment.pendingRebookTime = undefined;
+    }
+  }
+
   // ------------------------------------------------------
   // Step 1 — Confirm/Initialize Booking Payment
   // ------------------------------------------------------
@@ -227,6 +239,7 @@ export class BookingService {
         for (const appointment of appointments) {
           appointment.status = AppointmentStatus.CONFIRMED;
           appointment.paymentStatus = PaymentStatus.PAID;
+          this.applyPendingRebookDate(appointment);
         }
         await manager.save(Appointment, appointments);
 
@@ -349,6 +362,7 @@ export class BookingService {
         for (const appointment of appointments) {
           appointment.status = AppointmentStatus.CONFIRMED;
           appointment.paymentStatus = PaymentStatus.UNPAID; // Pay at venue - will be paid later
+          this.applyPendingRebookDate(appointment);
         }
         await manager.save(Appointment, appointments);
 
@@ -733,6 +747,7 @@ export class BookingService {
         for (const appointment of appointments) {
           appointment.status = AppointmentStatus.CONFIRMED;
           appointment.paymentStatus = PaymentStatus.PAID;
+          this.applyPendingRebookDate(appointment);
         }
         await manager.save(Appointment, appointments);
 
@@ -896,6 +911,7 @@ export class BookingService {
         for (const appointment of appointments) {
           appointment.status = AppointmentStatus.CONFIRMED;
           appointment.paymentStatus = PaymentStatus.PAID;
+          this.applyPendingRebookDate(appointment);
         }
         await manager.save(Appointment, appointments);
 
@@ -994,6 +1010,7 @@ export class BookingService {
       .set({
         status: AppointmentStatus.CANCELLED,
         cancellationsNote: 'Payment not completed in time — booking expired',
+        cancelledAt: new Date(),
       })
       .where('client_id = :userId', { userId })
       .andWhere('status = :status', { status: AppointmentStatus.PENDING })
@@ -1117,9 +1134,18 @@ export class BookingService {
       refundPlans.push({ spi, refundAmountCents });
     }
 
-    // Update status and add cancellation note
+    // Update status and add cancellation note. paymentStatus is reset to
+    // UNPAID here too — any money that was actually collected has either
+    // been refunded (Stripe) or was never charged (pay-at-venue), so a
+    // stale PAID flag must not survive a cancellation. This is also what
+    // makes restoreBooking's Pending/Unpaid restore below meaningful: a
+    // cancelled appointment restored later needs to go through real
+    // payment again, not silently re-appear as already paid.
+    const cancelledAt = new Date();
     for (const appointment of appointmentsToCancel) {
       appointment.status = AppointmentStatus.CANCELLED;
+      appointment.paymentStatus = PaymentStatus.UNPAID;
+      appointment.cancelledAt = cancelledAt;
       if (cancellationsNote) {
         appointment.cancellationsNote = cancellationsNote;
       }
@@ -1216,8 +1242,20 @@ export class BookingService {
     };
   }
 
-  // Restore Cancelled Booking
-  async restoreBooking(orderId: string): Promise<{ message: string }> {
+  // Restore-eligibility check for a Cancelled booking on its original
+  // date/time (no reschedule). This does NOT change status/paymentStatus —
+  // a cancelled appointment must not look "un-cancelled" until the customer
+  // actually pays again. confirmBooking (pay-at-venue/gift-card) or the
+  // Stripe webhook (handleStripePaymentSucceeded) are the only places that
+  // flip status back, once payment genuinely succeeds. If the customer
+  // abandons the payment page after this call, nothing was ever changed —
+  // the appointment simply stays Cancelled, exactly as if Restore was never
+  // clicked.
+  private static readonly RESTORE_CUTOFF_HOURS = 24;
+
+  async restoreBooking(
+    orderId: string,
+  ): Promise<{ message: string; requiresPayment: boolean }> {
     const appointment = await this.bookingRepository.findOne({
       where: { orderId },
       relations: ['client'],
@@ -1232,36 +1270,26 @@ export class BookingService {
       );
     }
 
-    appointment.status = AppointmentStatus.CONFIRMED; // Restore to confirmed status
-    appointment.cancellationsNote = undefined; // Clear cancellation note on restore
-    await this.bookingRepository.save(appointment);
+    // Restoring onto the same date/time only makes sense if that date/time
+    // is still far enough out — a same-day-tomorrow slot may already be
+    // unavailable/re-booked by someone else. Rebook (which picks a new
+    // date/time) is the correct path once this close; Restore is not.
+    const appointmentDateTime = new Date(
+      `${appointment.date}T${appointment.time}`,
+    );
+    const hoursUntilAppointment =
+      (appointmentDateTime.getTime() - Date.now()) / (1000 * 60 * 60);
 
-    if (appointment.client?.email) {
-      try {
-        this.logger.log(
-          `Sending restore confirmation email to ${appointment.client.email} for order ${orderId}`,
-        );
-        this.emailService.sendBookingRestoredEmail(
-          appointment.client.email,
-          appointment.client.firstName || 'Valued Customer',
-          appointment.business?.businessName || 'the salon',
-          appointment.serviceName || 'your service',
-          appointment.date,
-          appointment.time,
-        );
-      } catch (emailError) {
-        this.logger.error(
-          `Failed to send restore confirmation email for order ${orderId}: ${emailError.message}`,
-          emailError.stack,
-        );
-      }
-    } else {
-      this.logger.warn(
-        `No client email found for order ${orderId} — skipping restore email`,
+    if (hoursUntilAppointment < BookingService.RESTORE_CUTOFF_HOURS) {
+      throw new BadRequestException(
+        `This appointment is too close to its original date/time to restore directly. Use Rebook to pick a new date instead.`,
       );
     }
 
-    return { message: 'Appointment restored successfully' };
+    return {
+      message: 'Appointment is eligible to restore — proceed to payment',
+      requiresPayment: true,
+    };
   }
 
   // Client confirms their own intent to attend
@@ -1291,7 +1319,7 @@ export class BookingService {
     orderId: string,
     newDate: Date,
     newTime: string,
-  ): Promise<{ message: string }> {
+  ): Promise<{ message: string; requiresPayment: boolean }> {
     const appointment = await this.bookingRepository.findOne({
       where: { orderId },
       relations: ['client'],
@@ -1299,7 +1327,35 @@ export class BookingService {
     if (!appointment) {
       throw new NotFoundException('Appointment not found');
     }
+
+    // Rebooking a previously-cancelled appointment onto a new date must go
+    // through real payment again — any earlier payment was already
+    // refunded (Stripe) or never taken (pay-at-venue) at cancellation
+    // time. Rescheduling an already-paid, still-active appointment to a
+    // different time is a separate case and must NOT touch payment status
+    // — the customer already paid, moving the date doesn't un-pay them.
+    const isRebookOfCancelled =
+      appointment.status === AppointmentStatus.CANCELLED;
+
     const formattedDate = newDate.toISOString().split('T')[0];
+
+    if (isRebookOfCancelled) {
+      // Stage the new date/time only — the appointment stays exactly as it
+      // was (Cancelled, original date/time) until payment actually
+      // succeeds. confirmBooking/handleStripePaymentSucceeded promote
+      // these into date/time and flip status once payment completes. If
+      // the customer abandons the payment page, nothing here was ever
+      // changed.
+      appointment.pendingRebookDate = formattedDate;
+      appointment.pendingRebookTime = newTime;
+      await this.bookingRepository.save(appointment);
+
+      return {
+        message: 'New date selected — proceed to payment to confirm',
+        requiresPayment: true,
+      };
+    }
+
     appointment.date = formattedDate;
     appointment.time = newTime;
     appointment.status = AppointmentStatus.RESCHEDULED;
@@ -1316,7 +1372,10 @@ export class BookingService {
       );
     }
 
-    return { message: 'Appointment rescheduled successfully' };
+    return {
+      message: 'Appointment rescheduled successfully',
+      requiresPayment: false,
+    };
   }
 
   // Get Booking Fees

--- a/src/user/services/booking.service.ts
+++ b/src/user/services/booking.service.ts
@@ -853,7 +853,10 @@ export class BookingService {
   // Unlike completeBooking (Paystack), this does NOT credit the business
   // wallet — Stripe-funded bookings stay HELD until the appointment is
   // marked Completed (see BusinessService.completeBooking's release hook).
-  async handleStripePaymentSucceeded(paymentIntentId: string): Promise<void> {
+  async handleStripePaymentSucceeded(
+    paymentIntentId: string,
+    chargeId?: string | null,
+  ): Promise<void> {
     const spi = await this.stripePaymentIntentRepository.findOne({
       where: { stripePaymentIntentId: paymentIntentId },
     });
@@ -867,6 +870,10 @@ export class BookingService {
     // Webhooks can be delivered more than once — no-op if already processed.
     if (spi.status !== StripeEscrowStatus.PENDING) {
       return;
+    }
+
+    if (chargeId) {
+      spi.stripeChargeId = chargeId;
     }
 
     const orderId = spi.orderId;
@@ -944,6 +951,29 @@ export class BookingService {
     );
   }
 
+  // Refund policy: the customer gets back the service amount minus KHS's
+  // own platform fee minus Stripe's real processing fee for that specific
+  // charge (looked up from Stripe, not estimated — the exact rate varies
+  // by card type/country). Returns the refundable amount in cents: 0 or
+  // negative means there's nothing left to refund after those deductions.
+  private async calculateStripeRefundAmountCents(
+    spi: StripePaymentIntent,
+  ): Promise<number> {
+    if (!spi.stripeChargeId) {
+      throw new BadRequestException(
+        `Stripe charge ID missing for payment intent ${spi.stripePaymentIntentId} — cannot compute refund`,
+      );
+    }
+
+    const stripeFeeCents = await this.stripeService.getChargeFee(
+      spi.stripeChargeId,
+    );
+    const bookingAmountCents = Math.round(spi.bookingAmount * 100);
+    const platformFeeCents = Math.round(spi.feeAmount * 100);
+
+    return bookingAmountCents - platformFeeCents - stripeFeeCents;
+  }
+
   // Get User Bookings
   // Appointments are created as PENDING the moment a client picks a date/
   // time, before payment — holding the slot while they go through the
@@ -1002,6 +1032,12 @@ export class BookingService {
     message: string;
     cancelledCount: number;
     remainingCount: number;
+    refund?: {
+      amount: number;
+      currency: string;
+      platformFeeWithheld: number;
+      stripeFeeWithheld: number;
+    };
   }> {
     if (!acceptedTerms) {
       throw new BadRequestException(
@@ -1060,6 +1096,27 @@ export class BookingService {
       );
     }
 
+    // Pre-flight: work out the actual refund amount for any Stripe escrow
+    // held on this booking BEFORE cancelling anything. The customer gets
+    // back the service amount minus KHS's own platform fee minus Stripe's
+    // real processing fee (looked up from the charge, not estimated) — if
+    // that math goes to zero or negative, the whole cancellation is
+    // blocked rather than silently refunding nothing.
+    const heldPaymentIntents = await this.stripePaymentIntentRepository.find({
+      where: { orderId, status: StripeEscrowStatus.HELD },
+    });
+
+    const refundPlans: { spi: StripePaymentIntent; refundAmountCents: number }[] = [];
+    for (const spi of heldPaymentIntents) {
+      const refundAmountCents = await this.calculateStripeRefundAmountCents(spi);
+      if (refundAmountCents <= 0) {
+        throw new BadRequestException(
+          `Cannot cancel: after deducting the platform fee and Stripe's processing fee, no refundable amount remains for order ${orderId}. Contact an admin to review.`,
+        );
+      }
+      refundPlans.push({ spi, refundAmountCents });
+    }
+
     // Update status and add cancellation note
     for (const appointment of appointmentsToCancel) {
       appointment.status = AppointmentStatus.CANCELLED;
@@ -1075,19 +1132,32 @@ export class BookingService {
     // StripePaymentIntent row. Nothing was ever credited to the wallet at
     // HELD time, so unlike Paystack there's no wallet balance to reverse
     // here — only the Stripe-side charge itself needs refunding.
-    try {
-      const heldPaymentIntents = await this.stripePaymentIntentRepository.find({
-        where: { orderId, status: StripeEscrowStatus.HELD },
-      });
+    let refundSummary:
+      | { amount: number; currency: string; platformFeeWithheld: number; stripeFeeWithheld: number }
+      | undefined;
 
-      for (const spi of heldPaymentIntents) {
+    try {
+      for (const { spi, refundAmountCents } of refundPlans) {
         const stripeRefund = await this.stripeService.createRefund({
           paymentIntentId: spi.stripePaymentIntentId,
+          amount: refundAmountCents,
         });
 
         spi.status = StripeEscrowStatus.REFUNDED;
         spi.refundedAt = new Date();
         await this.stripePaymentIntentRepository.save(spi);
+
+        const bookingAmountCents = Math.round(spi.bookingAmount * 100);
+        const platformFeeCents = Math.round(spi.feeAmount * 100);
+        const stripeFeeCents =
+          bookingAmountCents - platformFeeCents - refundAmountCents;
+
+        refundSummary = {
+          amount: refundAmountCents / 100,
+          currency: spi.currency.toUpperCase(),
+          platformFeeWithheld: platformFeeCents / 100,
+          stripeFeeWithheld: stripeFeeCents / 100,
+        };
 
         const debitTx = await this.transactionRepository.findOne({
           where: {
@@ -1102,10 +1172,10 @@ export class BookingService {
             this.refundRepository.create({
               transactionId: debitTx.id,
               userId: spi.userId,
-              amount: spi.amount,
+              amount: refundAmountCents / 100,
               currency: spi.currency.toUpperCase(),
               reason: cancellationsNote || 'Booking cancelled before completion',
-              adminNote: `Stripe refund ${stripeRefund.id}`,
+              adminNote: `Stripe refund ${stripeRefund.id} (platform fee + Stripe processing fee withheld)`,
               status: RefundStatus.PROCESSED,
               refundMethod: RefundMethod.CARD_REFUND,
             }),
@@ -1142,6 +1212,7 @@ export class BookingService {
       message: `${appointmentsToCancel.length} appointment(s) cancelled successfully`,
       cancelledCount: appointmentsToCancel.length,
       remainingCount,
+      refund: refundSummary,
     };
   }
 

--- a/src/user/services/booking.service.ts
+++ b/src/user/services/booking.service.ts
@@ -728,7 +728,35 @@ export class BookingService {
   }
 
   // Get User Bookings
+  // Appointments are created as PENDING the moment a client picks a date/
+  // time, before payment — holding the slot while they go through the
+  // payment page. If they never come back to pay, the row would otherwise
+  // sit forever looking like a real upcoming booking. Lazily expire any
+  // PENDING appointment older than this on every fetch, rather than
+  // running a background job for it.
+  private static readonly PENDING_EXPIRY_MINUTES = 30;
+
+  private async expireStalePendingBookings(userId: string): Promise<void> {
+    const cutoff = new Date(
+      Date.now() - BookingService.PENDING_EXPIRY_MINUTES * 60 * 1000,
+    );
+
+    await this.bookingRepository
+      .createQueryBuilder()
+      .update(Appointment)
+      .set({
+        status: AppointmentStatus.CANCELLED,
+        cancellationsNote: 'Payment not completed in time — booking expired',
+      })
+      .where('client_id = :userId', { userId })
+      .andWhere('status = :status', { status: AppointmentStatus.PENDING })
+      .andWhere('"createdAt" < :cutoff', { cutoff })
+      .execute();
+  }
+
   async getUserBookings(userId: string): Promise<Appointment[]> {
+    await this.expireStalePendingBookings(userId);
+
     return await this.bookingRepository.find({
       where: { client: { id: userId } },
       relations: ['business', 'service', 'staff'],

--- a/src/user/services/booking.service.ts
+++ b/src/user/services/booking.service.ts
@@ -433,8 +433,10 @@ export class BookingService {
       });
     }
 
-    // If remaining amount exists and no card ID provided, throw error
-    if (remainingToPay > 0 && !cardId) {
+    // If remaining amount exists and no card ID provided, throw error —
+    // Stripe doesn't use a pre-saved cardId the way Paystack does, so this
+    // guard only applies to the Paystack path.
+    if (paymentProvider !== 'stripe' && remainingToPay > 0 && !cardId) {
       throw new BadRequestException(
         'Payment method required for remaining amount',
       );

--- a/src/user/services/booking.service.ts
+++ b/src/user/services/booking.service.ts
@@ -26,6 +26,11 @@ import { PlatformSettingsService } from 'src/admin/platform-settings/platform-se
 import { EmailService } from 'src/email/email.service';
 import { NotificationSettingsService } from './notification-settings.service';
 import { PaystackService } from 'src/payment/paystack.service';
+import { StripeService } from 'src/payment/stripe.service';
+import {
+  StripePaymentIntent,
+  StripeEscrowStatus,
+} from 'src/payment/entities/stripe-payment-intent.entity';
 import { Card } from 'src/all_user_entities/card.entity';
 import { BusinessGiftCard } from 'src/business/entities/business-giftcard.entity';
 import { BusinessGiftCardStatus } from 'src/business/enum/gift-card.enum';
@@ -55,10 +60,13 @@ export class BookingService {
     private clientRepository: Repository<ClientSchema>,
     @InjectRepository(Card)
     private cardRepository: Repository<Card>,
+    @InjectRepository(StripePaymentIntent)
+    private stripePaymentIntentRepository: Repository<StripePaymentIntent>,
     private platformSettingsService: PlatformSettingsService,
     private reviewService: ReviewService,
     private readonly dataSource: DataSource,
     private readonly paystack: PaystackService,
+    private readonly stripeService: StripeService,
     private readonly walletService: BusinessWalletService,
     private readonly emailService: EmailService,
     private readonly notificationSettingsService: NotificationSettingsService,
@@ -129,7 +137,8 @@ export class BookingService {
   // Step 1 — Confirm/Initialize Booking Payment
   // ------------------------------------------------------
   async confirmBooking(confirmBookingDto: any, user: User): Promise<any> {
-    const { orderId, payAtVenue, cardId, giftCard } = confirmBookingDto;
+    const { orderId, payAtVenue, cardId, giftCard, paymentProvider } =
+      confirmBookingDto;
 
     // Find all appointments for this orderId
     const appointments = await this.bookingRepository.find({
@@ -438,6 +447,108 @@ export class BookingService {
       }
     }
 
+    // Handle card payment via Stripe — a fully separate path from Paystack
+    // below. Stripe funds are held in escrow (StripePaymentIntent) and only
+    // credited to the business wallet when the appointment is later marked
+    // Completed, unlike Paystack's immediate-credit-on-payment model.
+    if (paymentProvider === 'stripe' && remainingToPay > 0) {
+      const businessId = appointments[0].business.id;
+      const paymentIntent = await this.stripeService.createPaymentIntent({
+        amount: Math.round(remainingToPay * 100), // Convert to cents
+        currency: 'usd',
+        customerEmail: user.email,
+        metadata: {
+          orderId,
+          userId: user.id,
+          businessId,
+          bookingAmount,
+          feeAmount,
+        },
+      });
+
+      const stripePaymentIntent = this.stripePaymentIntentRepository.create({
+        orderId,
+        businessId,
+        userId: user.id,
+        stripePaymentIntentId: paymentIntent.id,
+        amount: remainingToPay,
+        currency: 'usd',
+        bookingAmount,
+        feeAmount,
+        status: StripeEscrowStatus.PENDING,
+      });
+      await this.stripePaymentIntentRepository.save(stripePaymentIntent);
+
+      const stripeTransactions: Transaction[] = [];
+
+      if (giftCardPayment > 0) {
+        stripeTransactions.push(
+          this.transactionRepository.create({
+            senderId: user.id,
+            recipientId: appointments[0].business.owner?.id,
+            amount: giftCardPayment,
+            type: TransactionType.DEBIT,
+            currency: WalletCurrency.USD,
+            description: `Gift card portion for appointment order ${orderId}`,
+            mode: 'Web',
+            referenceId: paymentIntent.id,
+            status: TxnStatus.PENDING,
+            method: PaymentMethod.GIFTCARD,
+            service: 'Booking',
+            customerName: `${user.firstName} ${user.surname}`,
+          }),
+        );
+      }
+
+      stripeTransactions.push(
+        this.transactionRepository.create({
+          senderId: user.id,
+          recipientId: appointments[0].business.owner?.id,
+          amount: remainingToPay,
+          type: TransactionType.DEBIT,
+          currency: WalletCurrency.USD,
+          description: `Card payment (Stripe) for appointment order ${orderId}`,
+          mode: 'Web',
+          referenceId: paymentIntent.id,
+          status: TxnStatus.PENDING,
+          method: PaymentMethod.STRIPE,
+          service: 'Booking',
+          customerName: `${user.firstName} ${user.surname}`,
+        }),
+      );
+
+      if (feeAmount > 0) {
+        stripeTransactions.push(
+          this.transactionRepository.create({
+            senderId: user.id,
+            amount: feeAmount,
+            type: TransactionType.FEE,
+            currency: WalletCurrency.USD,
+            description: `Platform fee for appointment order ${orderId}`,
+            mode: 'Web',
+            referenceId: paymentIntent.id,
+            status: TxnStatus.PENDING,
+            method: PaymentMethod.STRIPE,
+            service: 'Booking-Fee',
+            customerName: `${user.firstName} ${user.surname}`,
+          }),
+        );
+      }
+
+      await this.transactionRepository.save(stripeTransactions);
+
+      return {
+        message: 'Payment initialized',
+        bookingAmount,
+        platformFee: feeAmount,
+        totalAmount: roundedTotalAmount,
+        giftCardAmountUsed: giftCardPayment,
+        cardAmountToPay: remainingToPay,
+        clientSecret: paymentIntent.client_secret,
+        paymentIntentId: paymentIntent.id,
+      };
+    }
+
     // Handle card payment (Paystack) - Initialize payment
     const reference = `BKG-${Date.now()}-${Math.floor(Math.random() * 1000000)}`;
     let paystackInit: { reference: string; authorization_url: string } | null =
@@ -725,6 +836,103 @@ export class BookingService {
       message: 'Booking confirmed successfully',
       ...result,
     };
+  }
+
+  // ------------------------------------------------------
+  // Stripe — Handle payment_intent.succeeded webhook
+  // ------------------------------------------------------
+  // Unlike completeBooking (Paystack), this does NOT credit the business
+  // wallet — Stripe-funded bookings stay HELD until the appointment is
+  // marked Completed (see BusinessService.completeBooking's release hook).
+  async handleStripePaymentSucceeded(paymentIntentId: string): Promise<void> {
+    const spi = await this.stripePaymentIntentRepository.findOne({
+      where: { stripePaymentIntentId: paymentIntentId },
+    });
+    if (!spi) {
+      this.logger.warn(
+        `No StripePaymentIntent found for ${paymentIntentId} — ignoring webhook`,
+      );
+      return;
+    }
+
+    // Webhooks can be delivered more than once — no-op if already processed.
+    if (spi.status !== StripeEscrowStatus.PENDING) {
+      return;
+    }
+
+    const orderId = spi.orderId;
+
+    const result = await this.dataSource.manager.transaction(
+      async (manager) => {
+        const appointments = await manager.find(Appointment, {
+          where: { orderId },
+          relations: ['business', 'business.owner'],
+        });
+        if (appointments.length === 0) {
+          throw new NotFoundException('Appointments not found');
+        }
+
+        const user = await manager.findOne(User, {
+          where: { id: spi.userId },
+        });
+        if (!user) throw new NotFoundException('User not found');
+
+        for (const appointment of appointments) {
+          appointment.status = AppointmentStatus.CONFIRMED;
+          appointment.paymentStatus = PaymentStatus.PAID;
+        }
+        await manager.save(Appointment, appointments);
+
+        await manager.update(
+          Transaction,
+          { referenceId: paymentIntentId, service: 'Booking' },
+          { status: TxnStatus.COMPLETED },
+        );
+        await manager.update(
+          Transaction,
+          { referenceId: paymentIntentId, service: 'Booking-Fee' },
+          { status: TxnStatus.COMPLETED },
+        );
+
+        spi.status = StripeEscrowStatus.HELD;
+        spi.heldAt = new Date();
+        await manager.save(StripePaymentIntent, spi);
+
+        return {
+          appointments,
+          userEmail: user.email,
+          userFirstName: user.firstName,
+          shouldSendConfirmationEmail:
+            await this.shouldSendBookingConfirmationEmail(user),
+        };
+      },
+    );
+
+    if (result.userEmail && result.shouldSendConfirmationEmail) {
+      const serviceNames = [
+        ...new Set(result.appointments.map((a) => a.serviceName)),
+      ].join(', ');
+      this.emailService.sendBookingConfirmationEmail(
+        result.userEmail,
+        result.userFirstName || 'Valued Customer',
+        result.appointments[0].business?.businessName || 'the salon',
+        serviceNames,
+        result.appointments[0].date,
+        result.appointments[0].time,
+      );
+    }
+  }
+
+  // Stripe — Handle payment_intent.payment_failed webhook
+  async handleStripePaymentFailed(paymentIntentId: string): Promise<void> {
+    await this.stripePaymentIntentRepository.update(
+      { stripePaymentIntentId: paymentIntentId },
+      { status: StripeEscrowStatus.FAILED },
+    );
+    await this.transactionRepository.update(
+      { referenceId: paymentIntentId },
+      { status: TxnStatus.FAILED },
+    );
   }
 
   // Get User Bookings

--- a/src/user/services/salon.service.ts
+++ b/src/user/services/salon.service.ts
@@ -181,14 +181,33 @@ export class SalonService {
       .take(limit)
       .getManyAndCount();
 
-    // Load services separately to avoid join issues with pagination
-    for (const business of data) {
-      business.serviceList = await this.serviceRepo.find({
+    // Load services for all businesses in ONE query (not one query per
+    // business — that N+1 pattern was fine at ~20 rows but turned into 70+
+    // sequential round-trips once the dataset grew, visibly slowing the
+    // page down). Group in memory instead.
+    if (data.length > 0) {
+      const businessIds = data.map((b) => b.id);
+      const allServices = await this.serviceRepo.find({
         where: {
-          business: { id: business.id },
+          business: { id: In(businessIds) },
           ...(validServices.length > 0 ? { serviceType: In(validServices) } : {}),
         },
+        relations: ['business'],
       });
+
+      const servicesByBusinessId = new Map<string, Service[]>();
+      for (const service of allServices) {
+        const businessId = service.business?.id;
+        if (!businessId) continue;
+        if (!servicesByBusinessId.has(businessId)) {
+          servicesByBusinessId.set(businessId, []);
+        }
+        servicesByBusinessId.get(businessId)!.push(service);
+      }
+
+      for (const business of data) {
+        business.serviceList = servicesByBusinessId.get(business.id) ?? [];
+      }
     }
 
     return { data, total, page, limit };

--- a/src/user/services/salon.service.ts
+++ b/src/user/services/salon.service.ts
@@ -260,18 +260,21 @@ export class SalonService {
       .where('business.status = :status', { status: BusinessStatus.APPROVED })
       .getRawMany();
 
-    const locations = Array.from(
-      new Set(
-        businesses
-          .map((b) => {
-            const addr = b.address || '';
-            const parts = addr.split(',');
-            return parts[parts.length - 1]?.trim() || '';
-          })
-          .filter((loc) => loc.length > 0),
-      ),
-    );
+    // Dedup case-insensitively — the same location can arrive as "Lagos"
+    // from one seed/entry and "lagos" from another. Keyed by lowercase,
+    // keeping the first-seen casing as the canonical display value.
+    const seen = new Map<string, string>();
+    for (const b of businesses) {
+      const addr = b.address || '';
+      const parts = addr.split(',');
+      const loc = parts[parts.length - 1]?.trim() || '';
+      if (!loc) continue;
+      const key = loc.toLowerCase();
+      if (!seen.has(key)) {
+        seen.set(key, loc);
+      }
+    }
 
-    return locations.sort();
+    return Array.from(seen.values()).sort((a, b) => a.localeCompare(b));
   }
 }

--- a/src/webhook/controller/webhook.controller.ts
+++ b/src/webhook/controller/webhook.controller.ts
@@ -12,12 +12,76 @@ import {
 } from '@nestjs/common';
 import { Public } from 'src/business/middlewares/public.decorator';
 import { WebhookService } from '../services/webhook.service';
+import { StripeService } from 'src/payment/stripe.service';
+import { BookingService } from 'src/user/services/booking.service';
 
 @Controller('webhook')
 export class WebhookController {
   private readonly logger = new Logger(WebhookController.name);
 
-  constructor(private readonly webhookService: WebhookService) {}
+  constructor(
+    private readonly webhookService: WebhookService,
+    private readonly stripeService: StripeService,
+    private readonly bookingService: BookingService,
+  ) {}
+
+  /**
+   * Stripe webhook endpoint
+   * URL: POST /api/webhook/stripe
+   *
+   * Requires the raw request body (see the express.raw() middleware
+   * registered for this exact path in main.ts) — Stripe's signature
+   * verification needs the literal transmitted bytes, not parsed JSON.
+   */
+  @Public()
+  @Post('/stripe')
+  @HttpCode(HttpStatus.OK)
+  async handleStripeWebhook(
+    @Request() req,
+    @Headers('stripe-signature') signature: string,
+  ): Promise<{ received: boolean }> {
+    let event;
+    try {
+      event = this.stripeService.constructWebhookEvent(req.body, signature);
+    } catch (error) {
+      this.logger.error(
+        `Stripe webhook signature verification failed: ${error.message}`,
+      );
+      // A bad signature is not a transient failure — acknowledge so Stripe
+      // doesn't retry-storm, but do not process the (unverified) payload.
+      return { received: true };
+    }
+
+    try {
+      switch (event.type) {
+        case 'payment_intent.succeeded': {
+          const paymentIntent = event.data.object as { id: string };
+          await this.bookingService.handleStripePaymentSucceeded(
+            paymentIntent.id,
+          );
+          break;
+        }
+        case 'payment_intent.payment_failed': {
+          const paymentIntent = event.data.object as { id: string };
+          await this.bookingService.handleStripePaymentFailed(
+            paymentIntent.id,
+          );
+          break;
+        }
+        default:
+          this.logger.log(`Unhandled Stripe event type: ${event.type}`);
+      }
+    } catch (error) {
+      // A failed webhook is the only signal a payment succeeded — this is
+      // a real alert-worthy failure, not a best-effort background sync.
+      this.logger.error(
+        `Error processing Stripe webhook event ${event.type} (${event.id}): ${error.message}`,
+        error.stack,
+      );
+    }
+
+    return { received: true };
+  }
 
   /**
    * PayPal webhook endpoint

--- a/src/webhook/controller/webhook.controller.ts
+++ b/src/webhook/controller/webhook.controller.ts
@@ -55,9 +55,13 @@ export class WebhookController {
     try {
       switch (event.type) {
         case 'payment_intent.succeeded': {
-          const paymentIntent = event.data.object as { id: string };
+          const paymentIntent = event.data.object as {
+            id: string;
+            latest_charge: string | null;
+          };
           await this.bookingService.handleStripePaymentSucceeded(
             paymentIntent.id,
+            paymentIntent.latest_charge,
           );
           break;
         }

--- a/src/webhook/webhook.module.ts
+++ b/src/webhook/webhook.module.ts
@@ -7,15 +7,18 @@ import { WebhookController } from './controller/webhook.controller';
 import { WebhookService } from './services/webhook.service';
 import { PaymentModule } from 'src/admin/payment/payment.module';
 import { WalletPaymentMethod } from 'src/business/entities/payment-method.entity';
+import { StripeService } from 'src/payment/stripe.service';
+import { BookingModule } from 'src/user/modules/booking.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Wallet, Transaction, WalletPaymentMethod]),
     BusinessWalletModule,
     PaymentModule,
+    BookingModule,
   ],
   controllers: [WebhookController],
-  providers: [WebhookService],
+  providers: [WebhookService, StripeService],
   exports: [WebhookService],
 })
 export class WebhookModule {}


### PR DESCRIPTION
Summary

Full Stripe marketplace-escrow flow: PaymentIntent creation, webhook handling, funds held until the merchant marks the appointment Completed, admin manual override endpoints
Refund policy deducts the real platform fee plus Stripe's actual per-charge processing fee (looked up live from Stripe, not estimated), with a short retry to survive Stripe's async fee-attachment delay
Fixes a payment-integrity bug where Rebook/Restore un-cancelled an appointment before the customer had paid again — appointments now stay Cancelled until payment genuinely succeeds
Fixes an N+1 query in the salon listing endpoint causing multi-second load times once the dataset grew past ~70 businesses
Adds seed scripts for realistic salon test data (common + international)