### PR TITLE
fix: request modal err msg, stop platform fees from being sent to clIent transaction history

### DIFF
--- a/src/business/services/wallet.service.ts
+++ b/src/business/services/wallet.service.ts
@@ -585,6 +585,11 @@ export class BusinessWalletService {
         walletId,
       });
 
+      /* --------- EXCLUDE FEE TRANSACTIONS ---------- */
+      queryBuilder.andWhere('transaction.type != :feeType', {
+        feeType: TransactionType.FEE,
+      });
+
       /* --------- RELATIONS ---------- */
       queryBuilder.leftJoinAndSelect('transaction.sender', 'sender');
 

--- a/src/user/services/transaction.service.ts
+++ b/src/user/services/transaction.service.ts
@@ -81,6 +81,11 @@ export class TransactionService {
       { userId: user.id },
     );
 
+    // Exclude platform fee transactions from user transaction history
+    queryBuilder.andWhere('transaction.type != :feeType', {
+      feeType: TransactionType.FEE,
+    });
+
     // Load relations
     queryBuilder.leftJoinAndSelect('transaction.sender', 'sender');
     queryBuilder.leftJoinAndSelect('transaction.recipient', 'recipient');
@@ -223,7 +228,8 @@ export class TransactionService {
     if (transaction.senderId !== user.id) {
       return {
         success: false,
-        message: 'You can only request refunds for transactions you initiated',
+        // message: 'You can only request refunds for transactions you initiated',
+        message: 'Refund request failed',
       };
     }
 


### PR DESCRIPTION
SUMMARY
1. Update request refund action button error message.
2. Stop platform fees from getting to client transaction history
